### PR TITLE
feat: add first slog version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# golibs
-Birdie's standard library
+# Go Libs
+
+Birdie's standard library. This repository works as a monorepo of different Go modules
+that we use on our services and tools here at Birdie.

--- a/slog/go.mod
+++ b/slog/go.mod
@@ -1,0 +1,8 @@
+module github.com/birdie-ai/golibs/slog
+
+go 1.20
+
+require (
+	github.com/google/uuid v1.3.0
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
+)

--- a/slog/go.sum
+++ b/slog/go.sum
@@ -1,0 +1,4 @@
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=

--- a/slog/slog.go
+++ b/slog/slog.go
@@ -1,0 +1,238 @@
+// Package slog provides structured logging for our Go services
+// It is a wrapper for the https://pkg.go.dev/golang.org/x/exp/slog
+// With some extra functionality to configure levels and formatters.
+package slog
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+
+	"golang.org/x/exp/slog"
+)
+
+// It is a good idea to extract this package as an library that multiple
+// services can use. For now we have only one service in Go :-).
+
+// Level determines the importance or severity of a log record
+type Level = slog.Level
+
+// Logger represents a logger instance with its own context.
+type Logger = slog.Logger
+
+// Format determines the output format of the log records
+type Format string
+
+// Key represents a logging key/field
+type Key int
+
+// Tracing related keys
+const (
+	TraceID Key = iota
+	OrgID
+)
+
+// All available log levels
+const (
+	LevelInfo    Level = slog.LevelInfo
+	LevelDebug   Level = slog.LevelDebug
+	LevelWarn    Level = slog.LevelWarn
+	LevelError   Level = slog.LevelError
+	LevelDisable Level = math.MaxInt
+)
+
+// All available log formats
+const (
+	FormatText   = "text"
+	FormatGcloud = "gcloud"
+)
+
+// Default configurations
+const (
+	DefaultLevel  = slog.LevelInfo
+	DefaultFormat = FormatGcloud
+)
+
+// Config represents log configuration.
+type Config struct {
+	Level  Level
+	Format Format
+}
+
+// LoadConfig will load the log Config of the service from environment variables.
+// The service name is used as a prefix for the environment variables.
+// So a service "TEST" will load the log level from "TEST_LOG_LEVEL".
+//
+// Available log levels are: "debug", "info", "warn", "error"
+// Available log fmts are: "gcloud", "text"
+//
+// If the environment variables are not found it will use default values.
+func LoadConfig(service string) (Config, error) {
+	level := os.Getenv(service + "_LOG_LEVEL")
+	format := os.Getenv(service + "_LOG_FMT")
+
+	logFormat, err := validateFormat(format)
+	if err != nil {
+		return Config{}, err
+	}
+
+	logLevel, err := validateLogLevel(level)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return Config{
+		Level:  logLevel,
+		Format: logFormat,
+	}, nil
+}
+
+// Configure will change the default logger configuration.
+// It should be called as soon as possible, usually on the main of your program.
+func Configure(cfg Config) error {
+	th := slog.HandlerOptions{
+		Level: cfg.Level,
+	}
+
+	var handler slog.Handler
+
+	switch cfg.Format {
+	case FormatText:
+		handler = th.NewTextHandler(os.Stderr)
+	case FormatGcloud:
+		th.ReplaceAttr = func(groups []string, a slog.Attr) slog.Attr {
+			// Customize the name of some fields to match Google Cloud expectations
+			// More: https://cloud.google.com/logging/docs/agent/logging/configuration#process-payload
+			if a.Key == slog.LevelKey {
+				a.Key = "severity"
+			}
+			if a.Key == slog.MessageKey {
+				a.Key = "message"
+			}
+			return a
+		}
+		handler = th.NewJSONHandler(os.Stderr)
+	default:
+		return fmt.Errorf("unknown log format: %v", cfg.Format)
+	}
+
+	logger := slog.New(&tracedHandler{
+		handler: handler,
+	})
+	slog.SetDefault(logger)
+	return nil
+}
+
+// Info calls Logger.Info on the default logger.
+func Info(msg string, args ...any) {
+	slog.Info(msg, args...)
+}
+
+// Debug calls Logger.Debug on the default logger.
+func Debug(msg string, args ...any) {
+	slog.Debug(msg, args...)
+}
+
+// Warn calls Logger.Warn on the default logger.
+func Warn(msg string, args ...any) {
+	slog.Warn(msg, args...)
+}
+
+// Error calls Logger.Error on the default logger.
+func Error(msg string, args ...any) {
+	slog.Error(msg, args...)
+}
+
+// InfoCtx calls Logger.InfoCtx on the default logger.
+func InfoCtx(ctx context.Context, msg string, args ...any) {
+	slog.InfoCtx(ctx, msg, args...)
+}
+
+// DebugCtx calls Logger.DebugCtx on the default logger.
+func DebugCtx(ctx context.Context, msg string, args ...any) {
+	slog.DebugCtx(ctx, msg, args...)
+}
+
+// WarnCtx calls Logger.WarnCtx on the default logger.
+func WarnCtx(ctx context.Context, msg string, args ...any) {
+	slog.WarnCtx(ctx, msg, args...)
+}
+
+// ErrorCtx calls Logger.ErrorCtx on the default logger.
+func ErrorCtx(ctx context.Context, msg string, args ...any) {
+	slog.ErrorCtx(ctx, msg, args...)
+}
+
+// With calls Logger.With on the default logger returning a new Logger instance.
+func With(args ...any) *Logger {
+	return slog.With(args...)
+}
+
+type tracedHandler struct {
+	handler slog.Handler
+}
+
+func (t *tracedHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return t.handler.Enabled(ctx, l)
+}
+
+func (t *tracedHandler) Handle(ctx context.Context, record slog.Record) error {
+	if traceID, ok := getValue(ctx, TraceID); ok {
+		record.Add("trace_id", traceID)
+	}
+	if orgID, ok := getValue(ctx, OrgID); ok {
+		record.Add("organization_id", orgID)
+	}
+	return t.handler.Handle(ctx, record)
+}
+
+func getValue(ctx context.Context, key any) (string, bool) {
+	val := ctx.Value(key)
+	if val == nil {
+		return "", false
+	}
+	str, ok := val.(string)
+	if !ok {
+		return "", false
+	}
+	return str, true
+}
+
+func (t *tracedHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return t.handler.WithAttrs(attrs)
+}
+
+func (t *tracedHandler) WithGroup(name string) slog.Handler {
+	return t.handler.WithGroup(name)
+}
+
+func validateLogLevel(level string) (Level, error) {
+	level = strings.ToLower(level)
+	switch level {
+	case "info", "":
+		return LevelInfo, nil
+	case "debug":
+		return LevelDebug, nil
+	case "warn":
+		return LevelWarn, nil
+	case "error":
+		return LevelError, nil
+	case "disable":
+		return LevelDisable, nil
+	default:
+		return Level(666), fmt.Errorf("invalid log level: %q", level)
+	}
+}
+
+func validateFormat(format string) (Format, error) {
+	switch format {
+	case "gcloud", "text":
+		return Format(format), nil
+	case "":
+		return FormatGcloud, nil
+	default:
+		return "", fmt.Errorf("unknown log format %q", format)
+	}
+}

--- a/slog/slog_test.go
+++ b/slog/slog_test.go
@@ -1,0 +1,81 @@
+package slog_test
+
+import (
+	"testing"
+
+	"github.com/birdie-ai/golibs/slog"
+)
+
+func TestLoadConfigDefault(t *testing.T) {
+	config, err := slog.LoadConfig("DEFAULT")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if config.Level != slog.DefaultLevel {
+		t.Errorf("got %v, want default level %v", config.Level, slog.DefaultLevel)
+	}
+
+	if config.Format != slog.DefaultFormat {
+		t.Errorf("got %v, want default fmt %v", config.Format, slog.DefaultFormat)
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	t.Setenv(logLevelEnv, "debug")
+	t.Setenv(logFmtEnv, "text")
+
+	config, err := slog.LoadConfig(service)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if config.Level != slog.LevelDebug {
+		t.Errorf("got %v, want level %v", config.Level, slog.LevelDebug)
+	}
+
+	if config.Format != slog.FormatText {
+		t.Errorf("got %v, want fmt %v", config.Format, slog.FormatText)
+	}
+}
+
+func TestLoadConfigErr(t *testing.T) {
+	t.Setenv(logLevelEnv, "debug")
+	t.Setenv(logFmtEnv, "wrong")
+
+	config, err := slog.LoadConfig(service)
+	if err == nil {
+		t.Fatalf("expected error, got config: %v", config)
+	}
+
+	t.Setenv(logLevelEnv, "wrong")
+	t.Setenv(logFmtEnv, "text")
+
+	config, err = slog.LoadConfig(service)
+	if err == nil {
+		t.Fatalf("expected error, got config: %v", config)
+	}
+}
+
+func ExampleLoadConfig() {
+	_ = slog.Configure(slog.Config{
+		Level:  slog.LevelDebug,
+		Format: slog.FormatText,
+	})
+
+	slog.Info("info msg", "key", "val", "key2", 666)
+
+	_ = slog.Configure(slog.Config{
+		Level:  slog.LevelDebug,
+		Format: slog.FormatGcloud,
+	})
+
+	slog.Debug("debug msg", "key", "val", "key2", 666)
+}
+
+const (
+	service     = "TEST"
+	logLevelEnv = service + "_LOG_LEVEL"
+	logFmtEnv   = service + "_LOG_FMT"
+)

--- a/slog/tracing/tracing.go
+++ b/slog/tracing/tracing.go
@@ -1,0 +1,30 @@
+// Package tracing provides functions to help integrate logging with tracing.
+package tracing
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/birdie-ai/golibs/slog"
+	"github.com/google/uuid"
+)
+
+// Instrument will instrument the given handler by adding tracing context on the
+// request context.
+func Instrument(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		// We don't parse/generate trace IDs exactly as in the spec, for now
+		// just using the specified header name.
+		traceid := req.Header.Get("traceparent")
+
+		slog.Debug("traceparent header", "trace_id", traceid)
+
+		if traceid == "" {
+			traceid = uuid.NewString()
+			slog.Debug("header absent, generated UUID", "trace_id", traceid)
+		}
+
+		req = req.WithContext(context.WithValue(req.Context(), slog.TraceID, traceid))
+		h.ServeHTTP(res, req)
+	})
+}


### PR DESCRIPTION
Just adding our current slog. After we tag it we can start improving. Already have better ideas on how to handle adding fields and propagating the log context (the current way doesn't scale well and involve custom handlers). So we should have some improvements on the API coming soon.

The slog library is a thin wrapper around the experimental standard structured log that will be added on Go soon (it was already accepted). We can shift to the standard lib implementation with no impact on our code + there is some extra functionality that a more general/standard library won't do, ours is more specific in assuming things like tracing and config loading from env vars.