### PR TITLE
feat:tracing: add ctx keys

### DIFF
--- a/tracing/README.md
+++ b/tracing/README.md
@@ -1,0 +1,3 @@
+# Tracing
+
+Our `tracing` module provides common tracing functionality as used at Birdie.

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -2,6 +2,7 @@
 package tracing
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/birdie-ai/golibs/slog"
@@ -32,3 +33,31 @@ func InstrumentHTTP(h http.Handler) http.Handler {
 		h.ServeHTTP(res, req.WithContext(ctx))
 	})
 }
+
+// CtxWithTraceID creates a new [context.Context] with the given trace ID associated with it.
+// Call [CtxGetTraceID] to retrieve the trace ID.
+func CtxWithTraceID(ctx context.Context, traceID string) context.Context {
+	return context.WithValue(ctx, traceIDKey, traceID)
+}
+
+// CtxGetTraceID gets the trace ID associated with this context.
+// Return the trace ID and true if there is a trace ID, empty and false otherwise.
+func CtxGetTraceID(ctx context.Context) (string, bool) {
+	val := ctx.Value(traceIDKey)
+	if val == nil {
+		return "", false
+	}
+	traceID, ok := val.(string)
+	if !ok {
+		return "", false
+	}
+	return traceID, true
+}
+
+// key is the type used to store data on contexts.
+type key int
+
+const (
+	traceIDKey key = iota
+	orgIDKey
+)

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -44,7 +44,7 @@ func CtxWithTraceID(ctx context.Context, traceID string) context.Context {
 
 // CtxGetTraceID gets the trace ID associated with this context.
 // Return the trace ID and true if there is a trace ID, empty and false otherwise.
-func CtxGetTraceID(ctx context.Context) (string, bool) {
+func CtxGetTraceID(ctx context.Context) string {
 	return ctxget(ctx, traceIDKey)
 }
 
@@ -55,8 +55,7 @@ func CtxWithOrgID(ctx context.Context, orgID string) context.Context {
 }
 
 // CtxGetOrgID gets the trace ID associated with this context.
-// Return the trace ID and true if there is a trace ID, empty and false otherwise.
-func CtxGetOrgID(ctx context.Context) (string, bool) {
+func CtxGetOrgID(ctx context.Context) string {
 	return ctxget(ctx, orgIDKey)
 }
 
@@ -68,14 +67,14 @@ const (
 	orgIDKey
 )
 
-func ctxget(ctx context.Context, k key) (string, bool) {
+func ctxget(ctx context.Context, k key) string {
 	val := ctx.Value(k)
 	if val == nil {
-		return "", false
+		return ""
 	}
 	str, ok := val.(string)
 	if !ok {
-		return "", false
+		return ""
 	}
-	return str, true
+	return str
 }

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -56,6 +56,26 @@ func CtxGetTraceID(ctx context.Context) (string, bool) {
 	return traceID, true
 }
 
+// CtxWithOrgID creates a new [context.Context] with the given organization ID associated with it.
+// Call [CtxGetOrgID] to retrieve the organization ID.
+func CtxWithOrgID(ctx context.Context, orgID string) context.Context {
+	return context.WithValue(ctx, orgIDKey, orgID)
+}
+
+// CtxGetOrgID gets the trace ID associated with this context.
+// Return the trace ID and true if there is a trace ID, empty and false otherwise.
+func CtxGetOrgID(ctx context.Context) (string, bool) {
+	val := ctx.Value(orgIDKey)
+	if val == nil {
+		return "", false
+	}
+	orgID, ok := val.(string)
+	if !ok {
+		return "", false
+	}
+	return orgID, true
+}
+
 // key is the type used to store data on contexts.
 type key int
 

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -45,15 +45,7 @@ func CtxWithTraceID(ctx context.Context, traceID string) context.Context {
 // CtxGetTraceID gets the trace ID associated with this context.
 // Return the trace ID and true if there is a trace ID, empty and false otherwise.
 func CtxGetTraceID(ctx context.Context) (string, bool) {
-	val := ctx.Value(traceIDKey)
-	if val == nil {
-		return "", false
-	}
-	traceID, ok := val.(string)
-	if !ok {
-		return "", false
-	}
-	return traceID, true
+	return ctxget(ctx, traceIDKey)
 }
 
 // CtxWithOrgID creates a new [context.Context] with the given organization ID associated with it.
@@ -65,15 +57,7 @@ func CtxWithOrgID(ctx context.Context, orgID string) context.Context {
 // CtxGetOrgID gets the trace ID associated with this context.
 // Return the trace ID and true if there is a trace ID, empty and false otherwise.
 func CtxGetOrgID(ctx context.Context) (string, bool) {
-	val := ctx.Value(orgIDKey)
-	if val == nil {
-		return "", false
-	}
-	orgID, ok := val.(string)
-	if !ok {
-		return "", false
-	}
-	return orgID, true
+	return ctxget(ctx, orgIDKey)
 }
 
 // key is the type used to store data on contexts.
@@ -83,3 +67,15 @@ const (
 	traceIDKey key = iota
 	orgIDKey
 )
+
+func ctxget(ctx context.Context, k key) (string, bool) {
+	val := ctx.Value(k)
+	if val == nil {
+		return "", false
+	}
+	str, ok := val.(string)
+	if !ok {
+		return "", false
+	}
+	return str, true
+}

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -26,6 +26,8 @@ func InstrumentHTTP(h http.Handler) http.Handler {
 		}
 
 		ctx := req.Context()
+		ctx = CtxWithTraceID(ctx, traceid)
+
 		log := slog.FromCtx(ctx)
 		log = log.With("trace_id", traceid)
 		ctx = slog.NewContext(ctx, log)

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -36,22 +36,38 @@ func TestIntrumentedHTTPHandler(t *testing.T) {
 	}
 }
 
-func TestCtxWithTraceID(t *testing.T) {
-	const want = "trace-id-value"
+func TestCtxWithTraceAndOrgID(t *testing.T) {
+	const (
+		wantTraceID = "trace-id-value"
+		wantOrgID   = "org-id-value"
+	)
 	ctx := context.Background()
 
 	got, ok := tracing.CtxGetTraceID(ctx)
 	if ok {
 		t.Fatalf("unexpected trace id: %q", got)
 	}
+	got, ok = tracing.CtxGetOrgID(ctx)
+	if ok {
+		t.Fatalf("unexpected trace id: %q", got)
+	}
 
-	ctx = tracing.CtxWithTraceID(ctx, want)
+	ctx = tracing.CtxWithTraceID(ctx, wantTraceID)
+	ctx = tracing.CtxWithOrgID(ctx, wantOrgID)
 
 	got, ok = tracing.CtxGetTraceID(ctx)
 	if !ok {
 		t.Fatal("want trace ID")
 	}
-	if got != want {
-		t.Fatalf("got %q != want %q", got, want)
+	if got != wantTraceID {
+		t.Fatalf("got %q != want %q", got, wantTraceID)
+	}
+
+	got, ok = tracing.CtxGetOrgID(ctx)
+	if !ok {
+		t.Fatal("want org ID")
+	}
+	if got != wantOrgID {
+		t.Fatalf("got %q != want %q", got, wantTraceID)
 	}
 }

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -1,6 +1,7 @@
 package tracing_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -21,5 +22,25 @@ func TestIntrumentedHTTPHandler(t *testing.T) {
 
 	if got == nil {
 		t.Fatal("got nil logger")
+	}
+}
+
+func TestCtxWithTraceID(t *testing.T) {
+	const want = "trace-id-value"
+	ctx := context.Background()
+
+	got, ok := tracing.CtxGetTraceID(ctx)
+	if ok {
+		t.Fatalf("unexpected trace id: %q", got)
+	}
+
+	ctx = tracing.CtxWithTraceID(ctx, want)
+
+	got, ok = tracing.CtxGetTraceID(ctx)
+	if !ok {
+		t.Fatal("want trace ID")
+	}
+	if got != want {
+		t.Fatalf("got %q != want %q", got, want)
 	}
 }

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -18,7 +18,7 @@ func TestIntrumentedHTTPHandler(t *testing.T) {
 	)
 	handler := tracing.InstrumentHTTP(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		gotLogger = slog.FromCtx(req.Context())
-		gotTraceID, _ = tracing.CtxGetTraceID(req.Context())
+		gotTraceID = tracing.CtxGetTraceID(req.Context())
 	}))
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
@@ -43,30 +43,24 @@ func TestCtxWithTraceAndOrgID(t *testing.T) {
 	)
 	ctx := context.Background()
 
-	got, ok := tracing.CtxGetTraceID(ctx)
-	if ok {
+	got := tracing.CtxGetTraceID(ctx)
+	if got != "" {
 		t.Fatalf("unexpected trace id: %q", got)
 	}
-	got, ok = tracing.CtxGetOrgID(ctx)
-	if ok {
+	got = tracing.CtxGetOrgID(ctx)
+	if got != "" {
 		t.Fatalf("unexpected trace id: %q", got)
 	}
 
 	ctx = tracing.CtxWithTraceID(ctx, wantTraceID)
 	ctx = tracing.CtxWithOrgID(ctx, wantOrgID)
 
-	got, ok = tracing.CtxGetTraceID(ctx)
-	if !ok {
-		t.Fatal("want trace ID")
-	}
+	got = tracing.CtxGetTraceID(ctx)
 	if got != wantTraceID {
 		t.Fatalf("got %q != want %q", got, wantTraceID)
 	}
 
-	got, ok = tracing.CtxGetOrgID(ctx)
-	if !ok {
-		t.Fatal("want org ID")
-	}
+	got = tracing.CtxGetOrgID(ctx)
 	if got != wantOrgID {
 		t.Fatalf("got %q != want %q", got, wantTraceID)
 	}


### PR DESCRIPTION
Adds a way to add org_id and trace_id on contexts and retrieve them. Also add the trace id on the context on the instrumentation code, so not only a logger instance is available, but also the trace ID.

The idea is to use this as a building block for a common publisher code, that will automatically retrieve trace ID + org ID to use on events.