### PR TITLE
feat: add raw subscription

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -101,11 +101,13 @@ func (r *RawSubscription) Serve(handler RawMessageHandler) error {
 				<-semaphore
 			}()
 			err := handler(msg.Body)
-			if err == nil {
-				msg.Ack()
-			} else {
-				msg.Nack()
+			if err != nil {
+				if msg.Nackable() {
+					msg.Nack()
+				}
+				return
 			}
+			msg.Ack()
 		}()
 	}
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -162,9 +162,9 @@ func TestRawSubscriptionServing(t *testing.T) {
 	servingDone := make(chan struct{})
 
 	go func() {
-		err := subscription.Serve(func(msg []byte) error {
-			t.Logf("handler called, msg: %v", string(msg))
-			gotMsgs <- msg
+		err := subscription.Serve(func(msg event.Message) error {
+			t.Logf("handler called, msg: %v", string(msg.Body()))
+			gotMsgs <- msg.Body()
 			// we block the handlers to ensure concurrency is being respected
 			<-handlersDone
 			return nil

--- a/event/go.mod
+++ b/event/go.mod
@@ -3,14 +3,18 @@ module github.com/birdie-ai/golibs/event
 go 1.20
 
 require (
+	github.com/birdie-ai/golibs/tracing v0.0.0-20230626100919-b731b736142e
+	github.com/google/go-cmp v0.5.9
+	gocloud.dev v0.30.0
+)
+
+require (
 	github.com/birdie-ai/golibs/slog v0.0.2 // indirect
-	github.com/birdie-ai/golibs/tracing v0.0.0-20230626100919-b731b736142e // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.11.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	gocloud.dev v0.30.0 // indirect
 	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // indirect
 	golang.org/x/net v0.11.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect

--- a/event/go.sum
+++ b/event/go.sum
@@ -1303,6 +1303,7 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.5.1/go.mod h1:Ct15B4yir3PLOP5jsy0GNeYVaIZs/MK/Jz5any1wFW0=
 github.com/google/go-pkcs11 v0.2.0/go.mod h1:6eQoGcuNJpa7jnd5pMGdkSaQpNDYvPlXWMcjXXThLlY=


### PR DESCRIPTION
Add a first raw subscription that delivers any message. We will build a more specific one on top of this that will handle our events envelopes. A follow up PR will add the subscription that we will usually use more, this one is suitable for legacy events that don't follow our new envelope format.