### PR TITLE
chore: add request_id to http requests

### DIFF
--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -31,6 +31,7 @@ func InstrumentHTTP(h http.Handler) http.Handler {
 
 		log := slog.FromCtx(ctx)
 		log = log.With("trace_id", traceid)
+		log = log.With("request_id", uuid.NewString())
 		ctx = slog.NewContext(ctx, log)
 
 		log.Debug("handling request", "url", req.URL, "method", req.Method)


### PR DESCRIPTION
When retrying some requests we use the same trace_id, then it is harder to be sure you are seeing request X handling trace Y. Adding a simple/unique per request ID, in these situations it can be used to be sure you are analyzing a single request flow (not others that had the same trace_id, logs can be unordered, so it gets messy).