### PR TITLE
refactor: function name should be consistent

### DIFF
--- a/service/metrics.go
+++ b/service/metrics.go
@@ -6,8 +6,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// MustRegister will register all metrics on the given registry.
-func MustRegister(registry *prometheus.Registry) {
+// MustRegisterMetrics will register all metrics on the given registry.
+func MustRegisterMetrics(registry *prometheus.Registry) {
 	registry.MustRegister(buildInfo)
 }
 

--- a/service/metrics_test.go
+++ b/service/metrics_test.go
@@ -10,6 +10,6 @@ import (
 func TestBuildInfoSample(*testing.T) {
 	// Just guarantee that it is not broken/panicking (like wrong labels/etc).
 	metricsRegistry := prometheus.NewRegistry()
-	service.MustRegister(metricsRegistry)
+	service.MustRegisterMetrics(metricsRegistry)
 	service.SampleBuildInfo()
 }


### PR DESCRIPTION
To be consistent with event.MustRegisterMetrics (a little longer but more clear too).