### PR TITLE
feat: add basic http instrumentation/metrics

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -15,3 +15,27 @@ Labels:
 
 * revision : the revision identifier for the current commit or checkout.
 * goversion : Go's version used on the service.
+
+#### http_requests_in_flight_total : gauge
+
+Amount of in flight HTTP requests on the service.
+
+#### http_request_duration_seconds : histogram
+
+HTTP request duration distribution
+
+Labels:
+
+* code    : HTTP status code, like `200`
+* method  : HTTP method of the request, like `POST`
+* handler : Path of the request, like `/request/path`
+
+#### http_requests_total : count
+
+Counts all HTTP requests handled by a service.
+
+Labels:
+
+* code    : HTTP status code, like `200`
+* method  : HTTP method of the request, like `POST`
+* handler : Path of the request, like `/request/path`

--- a/service/metrics_test.go
+++ b/service/metrics_test.go
@@ -1,15 +1,36 @@
 package service_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/birdie-ai/golibs/service"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-func TestBuildInfoSample(*testing.T) {
+func TestMetricInstrumentation(t *testing.T) {
 	// Just guarantee that it is not broken/panicking (like wrong labels/etc).
+	// We test everything together/integrated by design, it would be possible for one set of
+	// metrics to collide with some other, theoretically services should be able to use
+	// all the metrics exported on the pkg together, we should have no collisions.
 	metricsRegistry := prometheus.NewRegistry()
 	service.MustRegisterMetrics(metricsRegistry)
+	service.MustRegisterHTTPMetrics(metricsRegistry)
 	service.SampleBuildInfo()
+
+	called := false
+	handler := service.InstrumentHTTP(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		called = true
+	}))
+	handler = service.InstrumentHTTPByPath(handler, "/test")
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	res := httptest.NewRecorder()
+
+	handler.ServeHTTP(res, req)
+
+	if !called {
+		t.Fatal("want instrumented handler to be called")
+	}
 }


### PR DESCRIPTION
To avoid duplicating the basic metric instrumentation code + help us export consistent metrics across different services, at least for basic HTTP stuff (services still can have optional domain specific metrics).