### PR TITLE
chore: add request_id to each event

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/birdie-ai/golibs/slog"
 	"github.com/birdie-ai/golibs/tracing"
+	"github.com/google/uuid"
 	"gocloud.dev/pubsub"
 )
 
@@ -150,6 +151,7 @@ func (s *Subscription[T]) Serve(handler Handler[T]) error {
 		ctx = tracing.CtxWithTraceID(ctx, event.TraceID)
 		ctx = tracing.CtxWithOrgID(ctx, event.OrgID)
 
+		log = log.With("request_id", uuid.NewString())
 		log = log.With("trace_id", event.TraceID)
 		log = log.With("organization_id", event.OrgID)
 		ctx = slog.NewContext(ctx, log)


### PR DESCRIPTION
To handle situations where clients may send multiple requests with the same trace_id. We have some more details about this on our handbook, the idea is to have something that is GUARANTEED to be unique and per request/event/msg, independent of client behavior/etc, so filtering logs per request context is always trivial (and trace IDs can be used to correlate things across service boundaries).

Events are not request, but we want to have a common/unique name...and we went with request_id for now.