### PR TITLE
feat: add event.NewMessage function

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -187,7 +187,7 @@ func (r *MessageSubscription) Serve(handler MessageHandler) error {
 				<-semaphore
 			}()
 
-			err := handler(Message{body: msg.Body})
+			err := handler(NewMessage(msg.Body))
 			if err != nil {
 				if msg.Nackable() {
 					msg.Nack()
@@ -203,6 +203,11 @@ func (r *MessageSubscription) Serve(handler MessageHandler) error {
 // The subscription should not be used after this method is called.
 func (r *MessageSubscription) Shutdown(ctx context.Context) error {
 	return r.sub.Shutdown(ctx)
+}
+
+// NewMessage creates a new [Message] with the given body
+func NewMessage(body []byte) Message {
+	return Message{body: body}
 }
 
 // Body of the message.


### PR DESCRIPTION
If you want to test a MessageHandler you need to be able to create a Message to pass as a parameter. The current design doesn't allow it. Im not sure about the design of Message...my idea was to push into the direction of making the message immutable (quite a good property when debugging odd scenarios on message handling), but doing that in Go is not trivial (requires copying the []byte when accessing it..or else it is mutable anyway...)...so Im not sure the abstraction is worth its cost...Im open to alternatives..but keeping in line with the current abstraction would be to allow for it to be built with a function (since the fields are private).