### PR TITLE
feat: add metadata to subscription messages

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -23,13 +23,14 @@ type (
 
 	// Envelope represents the structure of all data that wraps all events.
 	Envelope[T any] struct {
-		// Metadata is publisher specific metadata. Including metadata that may be added by specific
+		TraceID string `json:"trace_id"`
+		OrgID   string `json:"organization_id"`
+		Name    string `json:"name"`
+		Event   T      `json:"event"`
+
+		// metadata is publisher specific metadata. Including metadata that may be added by specific
 		// pubsub brokers like Google Cloud PubSub.
-		Metadata map[string]string
-		TraceID  string `json:"trace_id"`
-		OrgID    string `json:"organization_id"`
-		Name     string `json:"name"`
-		Event    T      `json:"event"`
+		metadata map[string]string
 	}
 
 	// Subscription is a subscription that received only specific types of events
@@ -152,7 +153,7 @@ func (s *Subscription[T]) Serve(handler Handler[T]) error {
 			return fmt.Errorf("event name doesn't match %q: event: %v", s.name, msg)
 		}
 
-		event.Metadata = msg.Metadata()
+		event.metadata = msg.Metadata()
 
 		ctx = tracing.CtxWithTraceID(ctx, event.TraceID)
 		ctx = tracing.CtxWithOrgID(ctx, event.OrgID)
@@ -229,4 +230,9 @@ func (m Message) Metadata() map[string]string {
 // String representation of the message.
 func (m Message) String() string {
 	return string(m.body)
+}
+
+// Metadata returns all metadata associated with this event envelope.
+func (e Envelope[T]) Metadata() map[string]string {
+	return e.metadata
 }

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -77,9 +77,7 @@ func TestPublishEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want != got {
-		t.Fatalf("got %+v != want %+v", got, want)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestPublishEventWithoutTracingInfo(t *testing.T) {
@@ -126,9 +124,7 @@ func TestPublishEventWithoutTracingInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if want != got {
-		t.Fatalf("got %+v != want %+v", got, want)
-	}
+	assertEqual(t, got, want)
 }
 
 func TestSubscriptionServing(t *testing.T) {

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/birdie-ai/golibs/event"
 	"github.com/birdie-ai/golibs/tracing"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"gocloud.dev/pubsub"
 	_ "gocloud.dev/pubsub/mempubsub"
 )
@@ -77,7 +78,7 @@ func TestPublishEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertEqual(t, got, want)
+	assertEqual(t, got, want, cmpopts.IgnoreUnexported(got))
 }
 
 func TestPublishEventWithoutTracingInfo(t *testing.T) {
@@ -124,7 +125,7 @@ func TestPublishEventWithoutTracingInfo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assertEqual(t, got, want)
+	assertEqual(t, got, want, cmpopts.IgnoreUnexported(got))
 }
 
 func TestSubscriptionServing(t *testing.T) {
@@ -442,13 +443,13 @@ func newTopicURL(t *testing.T) string {
 	return "mem://" + t.Name()
 }
 
-func assertEqual[T any](t *testing.T, got T, want T) {
+func assertEqual[T any](t *testing.T, got T, want T, opts ...cmp.Option) {
 	t.Helper()
 	// parametric helps to ensure we don't compare things of different types (which doesn't make sense)
 	// so we want 2 of any that are of the same type.
 	// maybe this could be generalized in an small assert lib :-).
 
-	if diff := cmp.Diff(got, want); diff != "" {
+	if diff := cmp.Diff(got, want, opts...); diff != "" {
 		t.Logf("got: %v", got)
 		t.Logf("want: %v", want)
 		t.Fatalf("diff: %v", diff)


### PR DESCRIPTION
The idea is to get access to this metadata from Google PubSub: https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage

I don't think we will use this for metadata ourselves, we usually just model our own metadata inside the envelope, but Google metadata will be there so it seems that having at least a way to read metadata (but no way to define it) is enough. Not sure it is the best design..but I'm also not sure this will work to get this metadata, documentation is not super clear on this (if it doesn't work we can just remove it).

If this works then we can also add some tests, but first need to do some manual integration testing to see if this does what I think it does =P.