### PR TITLE
feat: event: handle panics on event handling

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -154,6 +154,11 @@ func NewRawSubscription(url string, maxConcurrency int) (*MessageSubscription, e
 // If a received event has the wrong name it will be discarded as malformed and a Nack will be sent automatically.
 // Serve may be called multiple times, each time will start a new serving service that will
 // run up to "maxConcurrency" goroutines.
+//
+// If the handler panics, the [Subscription] (the caller of the handler) assumes
+// that the effect of the panic was isolated to the active event handling.
+// It recovers the panic, logs a stack trace and returns an error (failing the event handling gracefully,
+// which in most event systems will trigger some form of retry).
 func (s *Subscription[T]) Serve(handler Handler[T]) error {
 	return s.rawsub.Serve(SampledMessageHandler(s.name, func(msg Message) error {
 		ctx, event, err := s.createEvent(msg)
@@ -222,6 +227,11 @@ func (s *Subscription[T]) Shutdown(ctx context.Context) error {
 // If a non-nil error is returned by the handler Unack will be sent.
 // Serve may be called multiple times, each time will start a new serving service that will
 // run up to "maxConcurrency" goroutines.
+//
+// If the handler panics, the [MessageSubscription] (the caller of the handler) assumes
+// that the effect of the panic was isolated to the active event handling.
+// It recovers the panic, logs a stack trace and returns an error (failing the event handling gracefully,
+// which in most event systems will trigger some form of retry).
 func (r *MessageSubscription) Serve(handler MessageHandler) error {
 	semaphore := make(chan struct{}, r.maxConcurrency)
 	for {
@@ -238,6 +248,19 @@ func (r *MessageSubscription) Serve(handler MessageHandler) error {
 			}()
 
 			id, publishedTime := getMetadata(msg)
+
+			//defer func() {
+			//if err := recover(); err != nil {
+			//const size = 64 << 10
+			//buf := make([]byte, size)
+			//buf = buf[:runtime.Stack(buf, false)]
+			//slog.Error("message subscription: panic handling message", "message", msg, "stack_trace", string(buf))
+			//if msg.Nackable() {
+			//msg.Nack()
+			//}
+			//}
+			//}()
+
 			err := handler(Message{
 				Body: msg.Body,
 				Metadata: Metadata{


### PR DESCRIPTION
Avoid crashing the entire program when the handling of a single event panics.
Very similar (and with copied code :-)) to Go's http stdlib.
