### PR TITLE
fix: only read non nil bodies on requests

### DIFF
--- a/xhttp/client.go
+++ b/xhttp/client.go
@@ -101,13 +101,19 @@ type (
 )
 
 func (r *retrierClient) Do(req *http.Request) (*http.Response, error) {
-	requestBody, err := io.ReadAll(req.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading request body: %w", err)
+	var requestBody []byte
+
+	if req.Body != nil {
+		var err error
+		requestBody, err = io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("reading request body: %w", err)
+		}
+		if err := req.Body.Close(); err != nil {
+			return nil, fmt.Errorf("closing request body: %w", err)
+		}
 	}
-	if err := req.Body.Close(); err != nil {
-		return nil, fmt.Errorf("closing request body: %w", err)
-	}
+
 	return r.do(req.Context(), req, requestBody, r.minPeriod)
 }
 


### PR DESCRIPTION
Since in some cases bodies are guaranteed to be non-nil (even if empty, on http.NewRequest()) I thought this was OK, but it wasn't...it segfaults...hard :rofl: (should have checked this anyway... plain stupid shit). Im in a rush so the tests are not great..but they do cover this now