### PR TITLE
fix: context cancellation with per request timeouts

### DIFF
--- a/xhttp/client.go
+++ b/xhttp/client.go
@@ -62,7 +62,16 @@ type (
 		sleep            func(context.Context, time.Duration)
 		retryStatusCodes map[int]struct{}
 	}
+	readerCloserCanceller struct {
+		io.ReadCloser
+		cancel context.CancelFunc
+	}
 )
+
+func (c *readerCloserCanceller) Close() error {
+	c.cancel()
+	return c.ReadCloser.Close()
+}
 
 func (r *retrierClient) Do(req *http.Request) (*http.Response, error) {
 	var requestBody []byte
@@ -87,12 +96,14 @@ func (r *retrierClient) do(ctx context.Context, req *http.Request, requestBody [
 		return nil, ctx.Err()
 	}
 	req, cancel := r.newRequest(ctx, req, requestBody)
-	defer cancel()
 
 	log := slog.FromCtx(ctx).With("request_url", req.URL)
 
 	res, err := r.client.Do(req)
 	if err != nil {
+		// TODO(katcipis): test this
+		//cancel()
+
 		// Sadly there is no other way to detect this error other than using the opaque string message
 		// The error type is internal and the http pkg does not provide a way to check it
 		// - https://cs.opensource.google/go/go/+/refs/tags/go1.21.4:src/net/http/h2_bundle.go;l=9250
@@ -116,6 +127,8 @@ func (r *retrierClient) do(ctx context.Context, req *http.Request, requestBody [
 		log.Debug("xhttp.Client: non recoverable error", "error", err)
 		return nil, err
 	}
+
+	res.Body = &readerCloserCanceller{res.Body, cancel}
 
 	_, isRetryCode := r.retryStatusCodes[res.StatusCode]
 	if isRetryCode {

--- a/xhttp/client_test.go
+++ b/xhttp/client_test.go
@@ -230,6 +230,9 @@ func TestRetrierPerRequestTimeoutWontCancelContext(t *testing.T) {
 	if req.Context().Err() == nil {
 		t.Fatal("want request context to be cancelled after closing response body")
 	}
+	if ctx.Err() != nil {
+		t.Fatal("parent context should not be cancelled after closing response body")
+	}
 }
 
 func TestRetrierExponentialBackoff(t *testing.T) {

--- a/xhttp/client_test.go
+++ b/xhttp/client_test.go
@@ -158,10 +158,10 @@ func TestRetrierPerRequestTimeoutCancelPerReqContextOnError(t *testing.T) {
 	// Guarantee that the context created for the request was cancelled
 	req := requests[0]
 	if req.Context().Err() == nil {
-		t.Fatal("want request context to be cancelled after response error")
+		t.Fatal("want request context to be cancelled after error response")
 	}
 	if ctx.Err() != nil {
-		t.Fatal("parent context should not be cancelled after response error")
+		t.Fatal("parent context should not be cancelled after error response")
 	}
 }
 

--- a/xhttp/client_test.go
+++ b/xhttp/client_test.go
@@ -210,7 +210,7 @@ func TestRetrierPerRequestTimeoutWontCancelContext(t *testing.T) {
 	// contexts to guarantee that the request context won't be cancelled before we read/close the response body.
 	req := requests[0]
 	if req.Context().Err() != nil {
-		t.Fatalf("request context is cancelled: %v", req.Context().Err())
+		t.Fatalf("want request context to not be cancelled before closing response body, got: %v", req.Context().Err())
 	}
 
 	gotBody, err := io.ReadAll(res.Body)

--- a/xhttptest/client.go
+++ b/xhttptest/client.go
@@ -68,11 +68,7 @@ func (c *Client) Requests() []*http.Request {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
-	clonedReqs := make([]*http.Request, len(c.requests))
-	for i, req := range c.requests {
-		clonedReqs[i] = req.Clone(req.Context())
-	}
-	return clonedReqs
+	return c.requests
 }
 
 // Do records requests and sends responses/errors.
@@ -86,7 +82,8 @@ func (c *Client) Do(req *http.Request) (*http.Response, error) {
 		c.callback(req)
 	}
 
-	c.requests = append(c.requests, req)
+	// We need to clone the request since the original request may be mutated after this method returns
+	c.requests = append(c.requests, req.Clone(req.Context()))
 
 	if len(c.responses) == 0 {
 		return nil, fmt.Errorf("no response configured on FakeClient for request: %v", req)


### PR DESCRIPTION
When we create per requests contexts we were cancelling the contexts before when we returning from Do,
this caused responses to fail when they are being read, since the response reading is part of the
original request context (and then can timeout/get cancelled).
