### PR TITLE
event: better log message for panic recovery

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -266,7 +266,7 @@ func (r *MessageSubscription) Serve(handler MessageHandler) error {
 					buf = buf[:runtime.Stack(buf, false)]
 					slog.Error("panic: message subscription: handling message",
 						"error", err,
-						"message", msg.Body,
+						"message_body", msg.Body,
 						"metadata", msg.Metadata,
 						"stack_trace", string(buf))
 					if gocloudMsg.Nackable() {

--- a/event/event.go
+++ b/event/event.go
@@ -256,9 +256,12 @@ func (r *MessageSubscription) Serve(handler MessageHandler) error {
 					const size = 64 << 10
 					buf := make([]byte, size)
 					buf = buf[:runtime.Stack(buf, false)]
+					messageID, publishTime := getMetadata(msg)
 					slog.Error("panic: message subscription: handling message",
 						"error", err,
-						"message_body", msg.Body,
+						"message_body", string(msg.Body),
+						"message_id", messageID,
+						"publish_time", publishTime,
 						"stack_trace", string(buf))
 					if msg.Nackable() {
 						msg.Nack()

--- a/event/event.go
+++ b/event/event.go
@@ -237,7 +237,7 @@ func (r *MessageSubscription) Serve(handler MessageHandler) error {
 	semaphore := make(chan struct{}, r.maxConcurrency)
 	for {
 		semaphore <- struct{}{}
-		msg, err := r.sub.Receive(context.Background())
+		gocloudMsg, err := r.sub.Receive(context.Background())
 		if err != nil {
 			// From: https://pkg.go.dev/gocloud.dev@v0.30.0/pubsub#example-Subscription.Receive-Concurrent
 			// Errors from Receive indicate that Receive will no longer succeed.
@@ -248,7 +248,15 @@ func (r *MessageSubscription) Serve(handler MessageHandler) error {
 				<-semaphore
 			}()
 
-			id, publishedTime := getMetadata(msg)
+			id, publishedTime := getMetadata(gocloudMsg)
+			msg := Message{
+				Body: gocloudMsg.Body,
+				Metadata: Metadata{
+					ID:            id,
+					PublishedTime: publishedTime,
+					Attributes:    gocloudMsg.Metadata,
+				},
+			}
 
 			defer func() {
 				if err := recover(); err != nil {
@@ -256,34 +264,25 @@ func (r *MessageSubscription) Serve(handler MessageHandler) error {
 					const size = 64 << 10
 					buf := make([]byte, size)
 					buf = buf[:runtime.Stack(buf, false)]
-					messageID, publishTime := getMetadata(msg)
 					slog.Error("panic: message subscription: handling message",
 						"error", err,
-						"message_body", string(msg.Body),
-						"message_id", messageID,
-						"publish_time", publishTime,
+						"message", msg.Body,
+						"metadata", msg.Metadata,
 						"stack_trace", string(buf))
-					if msg.Nackable() {
-						msg.Nack()
+					if gocloudMsg.Nackable() {
+						gocloudMsg.Nack()
 					}
 				}
 			}()
 
-			err := handler(Message{
-				Body: msg.Body,
-				Metadata: Metadata{
-					ID:            id,
-					PublishedTime: publishedTime,
-					Attributes:    msg.Metadata,
-				},
-			})
+			err := handler(msg)
 			if err != nil {
-				if msg.Nackable() {
-					msg.Nack()
+				if gocloudMsg.Nackable() {
+					gocloudMsg.Nack()
 				}
 				return
 			}
-			msg.Ack()
+			gocloudMsg.Ack()
 		}()
 	}
 }

--- a/event/event.go
+++ b/event/event.go
@@ -256,7 +256,10 @@ func (r *MessageSubscription) Serve(handler MessageHandler) error {
 					const size = 64 << 10
 					buf := make([]byte, size)
 					buf = buf[:runtime.Stack(buf, false)]
-					slog.Error("panic: message subscription: handling message", "message", msg, "stack_trace", string(buf))
+					slog.Error("panic: message subscription: handling message",
+						"error", err,
+						"message_body", msg.Body,
+						"stack_trace", string(buf))
 					if msg.Nackable() {
 						msg.Nack()
 					}


### PR DESCRIPTION
When event.MessageSubscription catches a panic in the message handler, we end up with this confusing error in the logs:

    !ERROR:json: unsupported type: func(func(inte

This change should result in a more useful log.