### PR TITLE
feat: add callback for requests on xhttp.RetrierClient

### DIFF
--- a/xhttp/client.go
+++ b/xhttp/client.go
@@ -109,9 +109,9 @@ func (r *retrierClient) do(ctx context.Context, req *http.Request, requestBody [
 
 	log := slog.FromCtx(ctx).With("request_url", req.URL)
 
+	start := time.Now()
 	res, err := r.client.Do(req)
-	// TODO: handle errors/responses and calculate proper elapsed
-	r.onRequestDone(req, res, err, 0)
+	r.onRequestDone(req, res, err, time.Since(start))
 	if err != nil {
 		cancel()
 

--- a/xhttp/client.go
+++ b/xhttp/client.go
@@ -23,6 +23,13 @@ type (
 	}
 	// RetrierOption is used to configure retrier clients created with [NewRetrierClient].
 	RetrierOption func(*retrierClient)
+
+	// RetrierOnRequestDoneFunc is the callback called when using [RetrierWithOnRequestDone].
+	// The [http.Request] is the original http request that just finished.
+	// The [time.Duration] is how long the http request took to be finished.
+	// This is called for every request that is done, including retries.
+	// Any changes made on the given [http.Request] may be reflected on retry behavior.
+	RetrierOnRequestDoneFunc func(req *http.Request, res *http.Response, elapsed time.Duration)
 )
 
 const (
@@ -37,10 +44,11 @@ const (
 // The returned [Client] will automatically retry failed requests.
 func NewRetrierClient(c Client, options ...RetrierOption) Client {
 	r := &retrierClient{
-		client:    c,
-		sleep:     defaultSleep,
-		minPeriod: DefaultMinSleepPeriod,
-		maxPeriod: DefaultMaxSleepPeriod,
+		client:        c,
+		sleep:         defaultSleep,
+		minPeriod:     DefaultMinSleepPeriod,
+		maxPeriod:     DefaultMaxSleepPeriod,
+		onRequestDone: defaultOnRequestDone,
 		retryStatusCodes: map[int]struct{}{
 			http.StatusInternalServerError: {},
 			http.StatusServiceUnavailable:  {},
@@ -61,6 +69,7 @@ type (
 		checkResponse    bool
 		sleep            func(context.Context, time.Duration)
 		retryStatusCodes map[int]struct{}
+		onRequestDone    RetrierOnRequestDoneFunc
 	}
 	readerCloserCanceller struct {
 		io.ReadCloser
@@ -109,7 +118,6 @@ func (r *retrierClient) do(ctx context.Context, req *http.Request, requestBody [
 		//
 		// For connections reset...same problem:
 		// - https://github.com/golang/go/blob/d0dc93c8e1a5be4e0a44b7f8ecb0cb1417de50ce/src/net/http/transport_test.go#L2207
-		// We need to go for some suffix matches.
 		if errors.Is(err, context.DeadlineExceeded) ||
 			strings.Contains(err.Error(), "http2: server sent GOAWAY and closed the connection") ||
 			strings.HasSuffix(err.Error(), "i/o timeout") ||
@@ -177,4 +185,7 @@ func defaultSleep(ctx context.Context, period time.Duration) {
 	sleepCtx, cancel := context.WithTimeout(ctx, period)
 	defer cancel()
 	<-sleepCtx.Done()
+}
+
+func defaultOnRequestDone(*http.Request, *http.Response, time.Duration) {
 }

--- a/xhttp/client.go
+++ b/xhttp/client.go
@@ -111,7 +111,7 @@ func (r *retrierClient) do(ctx context.Context, req *http.Request, requestBody [
 
 	res, err := r.client.Do(req)
 	// TODO: handle errors/responses and calculate proper elapsed
-	r.onRequestDone(req, nil, nil, 0)
+	r.onRequestDone(req, res, err, 0)
 	if err != nil {
 		cancel()
 

--- a/xhttp/client.go
+++ b/xhttp/client.go
@@ -26,8 +26,8 @@ type (
 
 	// RetrierOnRequestDoneFunc is the callback called when using [RetrierWithOnRequestDone].
 	// The [*http.Request] is the original http request that just finished.
-	// The [*http.Response] is the response of the request or nil if the request failed with an error (then the error will be non-nil).
-	// The [error] is the request error, if the request failed, or nil if it succeeded (and the response will be non-nil).
+	// The [*http.Response] is the response returned by the [Client.Do] call.
+	// The [error] is the response error returned by the [Client.Do] call.
 	// The [time.Duration] is how long the http request took to be finished.
 	// This is called for every request that is done, including retries.
 	RetrierOnRequestDoneFunc func(req *http.Request, res *http.Response, err error, elapsed time.Duration)

--- a/xhttp/client_opts.go
+++ b/xhttp/client_opts.go
@@ -6,7 +6,8 @@ import (
 )
 
 // RetrierWithOnRequestDone configures a callback function that will be called for each request done by the retrier.
-// This includes retried requests. The callback is called after a response is received but before the response is processed (for retrying).
+// This includes retried requests. The callback is called after a response/error is received but before the response/error is processed (for retrying).
+// The callback is called from the same goroutine that called the retrier Do method.
 func RetrierWithOnRequestDone(f RetrierOnRequestDoneFunc) RetrierOption {
 	return func(r *retrierClient) {
 		r.onRequestDone = f

--- a/xhttp/client_opts.go
+++ b/xhttp/client_opts.go
@@ -5,6 +5,14 @@ import (
 	"time"
 )
 
+// RetrierWithOnRequestDone configures a callback function that will be called for each request done by the retrier.
+// This includes retried requests. The callback is called after a response is received but before the response is processed (for retrying).
+func RetrierWithOnRequestDone(f RetrierOnRequestDoneFunc) RetrierOption {
+	return func(r *retrierClient) {
+		r.onRequestDone = f
+	}
+}
+
 // RetrierWithMinSleepPeriod configures the min period that the retrier will sleep between retries.
 // The retrier uses an exponential backoff, so this will be only the initial sleep period, that then grows exponentially.
 // If not defined it will default [DefaultMinSleepPeriod].

--- a/xhttp/client_test.go
+++ b/xhttp/client_test.go
@@ -312,7 +312,11 @@ func TestRetrierWithOnRequestDoneCallback(t *testing.T) {
 		assertEqual(t, got.StatusCode, want.StatusCode)
 	}
 
-	// TODO(katcipis): test both responses and errors
+	for i, got := range gotElapsed {
+		if got < minDelay {
+			t.Errorf("elapsed on call[%d] %v is smaller than min delay %v on Do() call", i, got, minDelay)
+		}
+	}
 }
 
 func TestRetrierExponentialBackoff(t *testing.T) {


### PR DESCRIPTION
This is a first building block for adding some client side metrics (also logging when desired).