### PR TITLE
feat: add on retry callback for xhttp.NewRetrierClient

### DIFF
--- a/xhttp/client_opts.go
+++ b/xhttp/client_opts.go
@@ -5,6 +5,16 @@ import (
 	"time"
 )
 
+// RetrierWithOnRetry configures a callback function that will be called for each request retry.
+// It includes only retried requests. The callback is called after a response/error is received
+// and it is decided that the request is a retry-able failure but before the request is actually retried.
+// The callback is called from the same goroutine that called the retrier Do method.
+func RetrierWithOnRetry(f RetrierOnRetryFunc) RetrierOption {
+	return func(r *retrierClient) {
+		r.onRetry = f
+	}
+}
+
 // RetrierWithOnRequestDone configures a callback function that will be called for each request done by the retrier.
 // This includes retried requests. The callback is called after a response/error is received but before the response/error is processed (for retrying).
 // The callback is called from the same goroutine that called the retrier Do method.


### PR DESCRIPTION
It overlaps a little with the on request done callback, but makes it easier to inspect when the retrier decided to retry some error, so building logging/metrics for retries will be more straightforward.