### PR TITLE
xhttp.Client: follow Retry-After header

### DIFF
--- a/xhttp/client.go
+++ b/xhttp/client.go
@@ -167,7 +167,7 @@ func (r *retrierClient) do(ctx context.Context, req *http.Request, requestBody [
 		switch {
 		case err != nil:
 			log.Warn(fmt.Sprintf("xhttp.Client: %v", err))
-		case requestedDuration > minRetryAfterDuration:
+		case requestedDuration >= minRetryAfterDuration:
 			log.Debug("xhttp.Client: following Retry-After header", "duration", requestedDuration)
 			sleepPeriod = requestedDuration
 		case !requestedTime.IsZero():

--- a/xhttp/client.go
+++ b/xhttp/client.go
@@ -172,7 +172,7 @@ func (r *retrierClient) do(ctx context.Context, req *http.Request, requestBody [
 			sleepPeriod = requestedDuration
 		case !requestedTime.IsZero():
 			calculatedDuration := time.Until(requestedTime)
-			if calculatedDuration > minRetryAfterDuration {
+			if calculatedDuration >= minRetryAfterDuration {
 				log.Debug("xhttp.Client: following Retry-After header", "time", requestedTime,
 					"calculated_duration", calculatedDuration)
 				sleepPeriod = calculatedDuration

--- a/xhttp/client.go
+++ b/xhttp/client.go
@@ -161,18 +161,18 @@ func (r *retrierClient) do(ctx context.Context, req *http.Request, requestBody [
 		r.onRetry(req, res, err)
 
 		// handle Retry-After header
-		const minSleepPeriod = time.Second
+		const minRetryAfterDuration = time.Second
 		retryAfter := res.Header.Get("Retry-After")
 		requestedDuration, requestedTime, err := ParseRetryAfter(retryAfter)
 		switch {
 		case err != nil:
 			log.Warn(fmt.Sprintf("xhttp.Client: %v", err))
-		case requestedDuration > minSleepPeriod:
+		case requestedDuration > minRetryAfterDuration:
 			log.Debug("xhttp.Client: following Retry-After header", "duration", requestedDuration)
 			sleepPeriod = requestedDuration
 		case !requestedTime.IsZero():
 			calculatedDuration := time.Until(requestedTime)
-			if calculatedDuration > minSleepPeriod {
+			if calculatedDuration > minRetryAfterDuration {
 				log.Debug("xhttp.Client: following Retry-After header", "time", requestedTime,
 					"calculated_duration", calculatedDuration)
 				sleepPeriod = calculatedDuration

--- a/xhttp/client.go
+++ b/xhttp/client.go
@@ -228,8 +228,8 @@ func ParseRetryAfter(value string) (time.Duration, time.Time, error) {
 	if value == "" {
 		return 0, time.Time{}, nil
 	}
-	if intValue, err := strconv.Atoi(value); err == nil {
-		return time.Duration(intValue) * time.Second, time.Time{}, nil
+	if seconds, err := strconv.Atoi(value); err == nil {
+		return time.Duration(seconds) * time.Second, time.Time{}, nil
 	}
 	if t, err := http.ParseTime(value); err == nil {
 		return 0, t, nil

--- a/xhttp/client_opts.go
+++ b/xhttp/client_opts.go
@@ -51,7 +51,6 @@ func RetrierWithRespCheck() RetrierOption {
 }
 
 // RetrierWithSleep configures the sleep function used to sleep between retries, usually used for testing.
-// But can be used as a way to measure how much retries happened since this is called before each retry.
 func RetrierWithSleep(sleep func(context.Context, time.Duration)) RetrierOption {
 	return func(r *retrierClient) {
 		r.sleep = sleep

--- a/xhttp/client_test.go
+++ b/xhttp/client_test.go
@@ -926,3 +926,17 @@ func TestParseRetryAfter(t *testing.T) {
 		}
 	}
 }
+
+func TestParseRetryAfterInvalid(t *testing.T) {
+	cases := []string{
+		"abc",
+		"1.5",
+		"Wed, 32 Oct 2015 07:28:00 GMT",
+	}
+	for _, c := range cases {
+		_, _, err := xhttp.ParseRetryAfter(c)
+		if err == nil {
+			t.Errorf("xhttp.ParseRetryAfter(%q) did not return error", c)
+		}
+	}
+}

--- a/xhttp/client_test.go
+++ b/xhttp/client_test.go
@@ -903,3 +903,26 @@ func assertEqual[T any](t *testing.T, got T, want T) {
 func retryableError() error {
 	return errors.New("http2: server sent GOAWAY and closed the connection")
 }
+
+func TestParseRetryAfter(t *testing.T) {
+	cases := []struct {
+		value string
+		d     time.Duration
+		tm    time.Time
+	}{
+		{value: ""},
+		{value: "123", d: 123 * time.Second},
+		{value: "Wed, 21 Oct 2015 07:28:00 GMT", tm: time.Date(2015, 10, 21, 7, 28, 0, 0, time.UTC)},
+	}
+	for _, c := range cases {
+		d, tm, err := xhttp.ParseRetryAfter(c.value)
+		if err != nil {
+			t.Errorf("ParseRetryAfter(%q) returned error: %v", c.value, err)
+		} else if !(d == c.d && tm.Equal(c.tm)) {
+			t.Errorf("ParseRetryAfter(%q) == (%v, %v, nil), want (%v, %v, nil)",
+				c.value,
+				d, tm,
+				c.d, c.tm)
+		}
+	}
+}


### PR DESCRIPTION
I want to start using the retrierClient to retry on status 429, but it seems like then we should also use the Retry-After header.