### PR TITLE
feat: add slog.NewGoogleCloudHandler

### DIFF
--- a/slog/slog.go
+++ b/slog/slog.go
@@ -13,20 +13,23 @@ import (
 	"strings"
 )
 
-// It is a good idea to extract this package as an library that multiple
-// services can use. For now we have only one service in Go :-).
+type (
+	// HandlerOptions are options for a [TextHandler] or [JSONHandler].
+	// A zero HandlerOptions consists entirely of default values.
+	HandlerOptions = slog.HandlerOptions
 
-// Level determines the importance or severity of a log record
-type Level = slog.Level
+	// Level determines the importance or severity of a log record
+	Level = slog.Level
 
-// Logger represents a logger instance with its own context.
-// It extends Go's slog.Logger by adding new methods, like [Logger.Fatal].
-type Logger struct {
-	*slog.Logger
-}
+	// Logger represents a logger instance with its own context.
+	// It extends Go's slog.Logger by adding new methods, like [Logger.Fatal].
+	Logger struct {
+		*slog.Logger
+	}
 
-// Format determines the output format of the log records
-type Format string
+	// Format determines the output format of the log records
+	Format string
+)
 
 // All available log levels
 const (

--- a/slog/slog.go
+++ b/slog/slog.go
@@ -14,6 +14,9 @@ import (
 )
 
 type (
+	// A Handler handles log records produced by a Logger.
+	Handler = slog.Handler
+
 	// HandlerOptions are options for a [TextHandler] or [JSONHandler].
 	// A zero HandlerOptions consists entirely of default values.
 	HandlerOptions = slog.HandlerOptions
@@ -95,6 +98,11 @@ func LoadConfig(service string) (Config, error) {
 		Level:  logLevel,
 		Format: logFormat,
 	}, nil
+}
+
+// New creates a new Logger with the given non-nil Handler.
+func New(h Handler) *Logger {
+	return &Logger{slog.New(h)}
 }
 
 // NewGoogleCloudHandler creates a [JSONHandler] that writes to w in a format that works well with Google Cloud Logging.

--- a/slog/slog_test.go
+++ b/slog/slog_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func ExampleNew() {
-	logger := slog.New(slog.NewGoogleCloudHandler(os.Stdout, &slog.HandlerOptions{
+	logger := slog.New(slog.NewGoogleCloudHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelWarn,
 	}))
 	logger.Info("omit", "a", 666)

--- a/slog/slog_test.go
+++ b/slog/slog_test.go
@@ -2,10 +2,19 @@ package slog_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/birdie-ai/golibs/slog"
 )
+
+func ExampleNew() {
+	logger := slog.New(slog.NewGoogleCloudHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	}))
+	logger.Info("omit", "a", 666)
+	logger.Warn("yeah", "b", "yeah")
+}
 
 func TestLoadConfigDefault(t *testing.T) {
 	config, err := slog.LoadConfig("DEFAULT")


### PR DESCRIPTION
Export the current google cloud handler as a function. Makes it easier for clients to create customized slog.Loggers (winking at @gustavom2998 :smile: ).

Also add some more aliases/slog.New to make it easier to create new sloggers that are not the default.