### PR TITLE
feat:tracing: add fine grained control over request stats

### DIFF
--- a/event/event_test.go
+++ b/event/event_test.go
@@ -308,7 +308,7 @@ func TestSubscriptionRecoversFromPanic(t *testing.T) {
 	servingDone := make(chan struct{})
 
 	go func() {
-		err := subscription.Serve(func(ctx context.Context, event Event) error {
+		err := subscription.Serve(func(_ context.Context, event Event) error {
 			gotEventsChan <- event
 			panic("oh no, something went terribly wrong")
 		})
@@ -367,7 +367,7 @@ func TestSubscriptionDiscardsEventsWithWrongName(t *testing.T) {
 	servingDone := make(chan struct{})
 
 	go func() {
-		err := subscription.Serve(func(ctx context.Context, event Event) error {
+		err := subscription.Serve(func(_ context.Context, event Event) error {
 			gotEvents <- event
 			return nil
 		})
@@ -565,7 +565,7 @@ func TestSubscriptionServingWithMetadata(t *testing.T) {
 
 	receivedMetadata := make(chan event.Metadata)
 	go func() {
-		err := subscription.ServeWithMetadata(func(ctx context.Context, event struct{}, metadata event.Metadata) error {
+		err := subscription.ServeWithMetadata(func(_ context.Context, _ struct{}, metadata event.Metadata) error {
 			receivedMetadata <- metadata
 			return nil
 		})

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 # tool versions
-golangci_lint_version := "v1.55.2"
+golangci_lint_version := "v1.60.1"
 
 # test and lint the code
 default: test lint

--- a/service/metrics_test.go
+++ b/service/metrics_test.go
@@ -20,7 +20,7 @@ func TestMetricInstrumentation(t *testing.T) {
 	service.SampleBuildInfo()
 
 	called := false
-	handler := service.InstrumentHTTP(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+	handler := service.InstrumentHTTP(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		called = true
 	}))
 	handler = service.InstrumentHTTPByPath(handler, "/test")

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -30,7 +30,9 @@ type StatsHandler func(context.Context, RequestStats)
 // Use slog.FromCtx(ctx) to retrieve the logger.
 // It will log each completed request on the INFO level (may be too much for some services, for more fine grained control see [InstrumentHTTPWithStats]).
 func InstrumentHTTP(h http.Handler) http.Handler {
-	return InstrumentHTTPWithStats(h, LogInfoRequestStats)
+	return InstrumentHTTPWithStats(h, func(ctx context.Context, req RequestStats) {
+		slog.FromCtx(ctx).Info("handled request", "http_request", req)
+	})
 }
 
 // InstrumentHTTPWithStats will instrument the given [http.handler] by adding a slog.Logger on the request context.
@@ -81,16 +83,6 @@ func InstrumentHTTPWithStats(h http.Handler, statsHandler StatsHandler) http.Han
 
 		h.ServeHTTP(resWriter, req.WithContext(ctx))
 	})
-}
-
-// LogInfoRequestStats will log the given request stats on INFO level.
-func LogInfoRequestStats(ctx context.Context, req RequestStats) {
-	slog.FromCtx(ctx).Info("handled request", "http_request", req)
-}
-
-// LogDebugRequestStats will log the given request stats on DEBUG level.
-func LogDebugRequestStats(ctx context.Context, req RequestStats) {
-	slog.FromCtx(ctx).Debug("handled request", "http_request", req)
 }
 
 // CtxWithTraceID creates a new [context.Context] with the given trace ID associated with it.

--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -71,7 +71,7 @@ func TestIntrumentedHTTPHandler(t *testing.T) {
 		gotTraceID = tracing.CtxGetTraceID(req.Context())
 		gotOrgID = tracing.CtxGetOrgID(req.Context())
 		w.WriteHeader(wantStatus)
-		fmt.Fprint(w, wantBody)
+		_, _ = fmt.Fprint(w, wantBody)
 		gotResponseWriter = w
 	}))
 
@@ -123,7 +123,7 @@ func TestIntrumentedHTTPHandlerNoFlusher(t *testing.T) {
 		gotTraceID = tracing.CtxGetTraceID(req.Context())
 		gotOrgID = tracing.CtxGetOrgID(req.Context())
 		w.WriteHeader(wantStatus)
-		fmt.Fprint(w, wantBody)
+		_, _ = fmt.Fprint(w, wantBody)
 		gotResponseWriter = w
 	}))
 	// Lets force the http.ResponseWriter to be non-flusheable


### PR DESCRIPTION
Some services handle way too much requests (dozens of millions per day). Logging each single request on the
INFO level is starting to generate considerable costs (and we rarely need those logs..if ever). In order to be
able to change this behavior Im introducing a new type and a callback for the request stats. The current default
behavior will be maintained.
