### PR TITLE
feat: add xhttp.NewJSONRequest

### DIFF
--- a/xhttp/request.go
+++ b/xhttp/request.go
@@ -1,7 +1,9 @@
 package xhttp
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"runtime/debug"
@@ -59,4 +61,14 @@ func NewRequestWithContext(ctx context.Context, method, url string, body io.Read
 	}
 	req.Header.Set("User-Agent", defaultUserAgent)
 	return req, nil
+}
+
+// NewJSONRequest is a wrapper that will marshall the given data as a JSON and call [NewRequestWithContext].
+// It makes it practical to create HTTP requests that send JSON bodies with detailed user agents (what we want most of the time).
+func NewJSONRequest(ctx context.Context, method, url string, data any) (*http.Request, error) {
+	body, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+	return NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
 }

--- a/xhttp/xhttp.go
+++ b/xhttp/xhttp.go
@@ -1,0 +1,57 @@
+package xhttp
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type (
+	// Response is an extension of [http.Response] that contains parsed data
+	// instead of a response body.
+	Response[T any] struct {
+		*http.Response
+		Obj T
+	}
+	// ResponseErr is the error returned by [Do] if parsing the response body fails.
+	ResponseErr struct {
+		Err  error
+		Body []byte
+	}
+)
+
+// Do calls [Client.Do] and unmarshalls the HTTP response as a JSON of type [T].
+// The returned [Response] embeds the original [http.Response] with the addition
+// of the [Response.Obj] field that holds the parsed response.
+//
+// The original [http.Response.Body] will always be read and closed, the caller should ignore
+// this field and use [Response.Obj] to access the parsed response or use errors.As
+// to check details in the case of an error (eg. debugging malformed JSON).
+//
+// If the response is not valid JSON an error of type [ResponseErr] is returned.
+func Do[T any](c Client, req *http.Request) (*Response[T], error) {
+	v, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(v.Body)
+	if err != nil {
+		return nil, errors.Join(err, v.Body.Close())
+	}
+	if err := v.Body.Close(); err != nil {
+		return nil, fmt.Errorf("xhttp: closing response body: %w", err)
+	}
+
+	var parsed T
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, ResponseErr{err, body}
+	}
+	return &Response[T]{v, parsed}, nil
+}
+
+func (r ResponseErr) Error() string {
+	return r.Err.Error()
+}

--- a/xhttp/xhttp_test.go
+++ b/xhttp/xhttp_test.go
@@ -1,0 +1,73 @@
+package xhttp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/birdie-ai/golibs/xhttp"
+)
+
+func TestDo(t *testing.T) {
+	type (
+		Error struct {
+			Message string
+		}
+		OK struct {
+			Success string
+		}
+		Response struct {
+			OK
+			Error Error
+		}
+	)
+
+	wantOK := Response{OK: OK{Success: "success !!!"}}
+	wantErr := Response{Error: Error{Message: "such error !!!"}}
+	var sendErr bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, _ *http.Request) {
+		if sendErr {
+			res.WriteHeader(http.StatusInternalServerError)
+			e := json.NewEncoder(res)
+			if err := e.Encode(wantErr); err != nil {
+				t.Error(err)
+			}
+			return
+		}
+		e := json.NewEncoder(res)
+		if err := e.Encode(wantOK); err != nil {
+			t.Error(err)
+		}
+	}))
+
+	c := &http.Client{}
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := xhttp.Do[Response](c, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("got status code %d; want %d", res.StatusCode, http.StatusOK)
+	}
+	if res.Obj != wantOK {
+		t.Fatalf("got response %v; want %v", res.Obj, wantOK)
+	}
+
+	sendErr = true
+	res, err = xhttp.Do[Response](c, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("got status code %d; want %d", res.StatusCode, http.StatusInternalServerError)
+	}
+	if res.Obj != wantErr {
+		t.Fatalf("got response %v; want %v", res.Obj, wantErr)
+	}
+}


### PR DESCRIPTION
My idea is to add a layer as small as possible just to make it easier to handle JSON on HTTP request/responses. Usually errors are disjointed from responses (different fields), so I'm thinking on always creating a type that is the union of whatever you expect as response + what you would expect if it is an error. After checking the status code then you can validate each part of the parsed data, the error for an error status code and the valid response for a success. This allows for more sophisticated things to be built on top, like something that already checks the status code and hides HTTP entirely, but not sure that is necessary/desirable once we have something that already makes it considerably less annoying to receive JSON (no more reading/error handling/parsing for every request).

The current design interoperates with anything that creates an [http.Request] and the [xhttp.Client] interface is implemented by Go's [http.Client] and our retrier (basically, everything just works :man_shrugging: ).