### PR TITLE
feat: add xhttp.Response.RawBody

### DIFF
--- a/xhttp/xhttp.go
+++ b/xhttp/xhttp.go
@@ -13,10 +13,10 @@ type (
 	// instead of a response body.
 	Response[T any] struct {
 		*http.Response
-		// RawObj is the raw response from where Obj was parsed (useful mostly for debugging).
-		RawObj []byte
-		// Obj is the parsed JSON response.
-		Obj T
+		// RawBody is the raw response from where Value was parsed (useful mostly for debugging).
+		RawBody []byte
+		// Value is the parsed JSON response.
+		Value T
 	}
 	// ResponseErr is the error returned by [Do] if parsing the response body fails.
 	ResponseErr struct {
@@ -52,7 +52,7 @@ func Do[T any](c Client, req *http.Request) (*Response[T], error) {
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil, ResponseErr{err, body}
 	}
-	return &Response[T]{Response: v, RawObj: body, Obj: parsed}, nil
+	return &Response[T]{Response: v, RawBody: body, Value: parsed}, nil
 }
 
 func (r ResponseErr) Error() string {

--- a/xhttp/xhttp.go
+++ b/xhttp/xhttp.go
@@ -13,6 +13,9 @@ type (
 	// instead of a response body.
 	Response[T any] struct {
 		*http.Response
+		// RawObj is the raw response from where Obj was parsed (useful mostly for debugging).
+		RawObj []byte
+		// Obj is the parsed JSON response.
 		Obj T
 	}
 	// ResponseErr is the error returned by [Do] if parsing the response body fails.
@@ -49,7 +52,7 @@ func Do[T any](c Client, req *http.Request) (*Response[T], error) {
 	if err := json.Unmarshal(body, &parsed); err != nil {
 		return nil, ResponseErr{err, body}
 	}
-	return &Response[T]{v, parsed}, nil
+	return &Response[T]{Response: v, RawObj: body, Obj: parsed}, nil
 }
 
 func (r ResponseErr) Error() string {

--- a/xhttp/xhttp_test.go
+++ b/xhttp/xhttp_test.go
@@ -71,11 +71,11 @@ func TestDo(t *testing.T) {
 	if res.StatusCode != http.StatusOK {
 		t.Fatalf("got status code %d; want %d", res.StatusCode, http.StatusOK)
 	}
-	if res.Obj != wantOK {
-		t.Fatalf("got response %v; want %v", res.Obj, wantOK)
+	if res.Value != wantOK {
+		t.Fatalf("got response %v; want %v", res.Value, wantOK)
 	}
-	if string(res.RawObj) != string(wantRawObj) {
-		t.Fatalf("got raw response %q; want %q", string(res.RawObj), string(wantRawObj))
+	if string(res.RawBody) != string(wantRawObj) {
+		t.Fatalf("got raw response %q; want %q", string(res.RawBody), string(wantRawObj))
 	}
 
 	sendErr = true
@@ -86,11 +86,11 @@ func TestDo(t *testing.T) {
 	if res.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("got status code %d; want %d", res.StatusCode, http.StatusInternalServerError)
 	}
-	if res.Obj != wantErr {
-		t.Fatalf("got response %v; want %v", res.Obj, wantErr)
+	if res.Value != wantErr {
+		t.Fatalf("got response %v; want %v", res.Value, wantErr)
 	}
-	if string(res.RawObj) != string(wantRawObj) {
-		t.Fatalf("got raw response %q; want %q", string(res.RawObj), string(wantRawObj))
+	if string(res.RawBody) != string(wantRawObj) {
+		t.Fatalf("got raw response %q; want %q", string(res.RawBody), string(wantRawObj))
 	}
 }
 


### PR DESCRIPTION
Should be useful mostly for debugging, but can help when an endpoint is sending you some JSON but it is different from what you expected (so parsing succeeds but information is not there).

Also renaming Obj to Value, Obj assumed too much about the structure.