### PR TITLE
feat: add tracing context request ID

### DIFF
--- a/tracing/tracing_test.go
+++ b/tracing/tracing_test.go
@@ -163,14 +163,19 @@ func TestIntrumentedHTTPHandlerNoFlusher(t *testing.T) {
 	}
 }
 
-func TestCtxWithTraceAndOrgID(t *testing.T) {
+func TestCtxWithTraceOrgRequestID(t *testing.T) {
 	const (
-		wantTraceID = "trace-id-value"
-		wantOrgID   = "org-id-value"
+		wantTraceID   = "trace-id-value"
+		wantRequestID = "request-id"
+		wantOrgID     = "org-id-value"
 	)
 	ctx := context.Background()
 
-	got := tracing.CtxGetTraceID(ctx)
+	got := tracing.CtxGetRequestID(ctx)
+	if got != "" {
+		t.Fatalf("unexpected request id: %q", got)
+	}
+	got = tracing.CtxGetTraceID(ctx)
 	if got != "" {
 		t.Fatalf("unexpected trace id: %q", got)
 	}
@@ -179,8 +184,14 @@ func TestCtxWithTraceAndOrgID(t *testing.T) {
 		t.Fatalf("unexpected trace id: %q", got)
 	}
 
+	ctx = tracing.CtxWithRequestID(ctx, wantRequestID)
 	ctx = tracing.CtxWithTraceID(ctx, wantTraceID)
 	ctx = tracing.CtxWithOrgID(ctx, wantOrgID)
+
+	got = tracing.CtxGetRequestID(ctx)
+	if got != wantRequestID {
+		t.Fatalf("got %q != want %q", got, wantRequestID)
+	}
 
 	got = tracing.CtxGetTraceID(ctx)
 	if got != wantTraceID {


### PR DESCRIPTION
We already had the request_id but only for logs. The request ID is good to identify specific request/responses when the same trace_id may be used (like in a retry). It is a more limited version of a span ID for tracing, but it is what we have today (we may have something more complete someday). With this we can add the request ID as metadata in an event related to a request and then easily correlate them (the trace ID is not enough...but maybe that is debatable...but right now I also don't have a whole lot of time).