### PR TITLE
feat(xhttp): add more retryable status codes.

### DIFF
--- a/xhttp/retrier.go
+++ b/xhttp/retrier.go
@@ -61,7 +61,9 @@ func NewRetrierClient(c Client, options ...RetrierOption) Client {
 		onRequestDone: defaultOnRequestDone,
 		onRetry:       defaultOnRetry,
 		retryStatusCodes: map[int]struct{}{
+			http.StatusTooManyRequests:     {},
 			http.StatusInternalServerError: {},
+			http.StatusBadGateway:          {},
 			http.StatusServiceUnavailable:  {},
 			http.StatusGatewayTimeout:      {},
 		},


### PR DESCRIPTION
Add `502 Bad Gateway` and `429 Too Many Requests` as retryable status codes.