### PR TITLE
Update Go version to fix vulncheck CI task

### DIFF
--- a/.github/workflows/vulncheck.yaml
+++ b/.github/workflows/vulncheck.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.24"
+          go-version: "1.25.5"
 
       - name: Install just
         uses: taiki-e/install-action@just


### PR DESCRIPTION
I'm still getting the alerts for this task because I set it up and it's a public repo :smile: 