### PR TITLE
feat: nested dml statements.

### DIFF
--- a/dml/README.md
+++ b/dml/README.md
@@ -478,15 +478,17 @@ WHERE id="abc";
 
 ## Nested Stmts
 
-In high-level terms, an entity is usually an array of documents.
+Set `feedbacks.text` inside the `orders` entity:
 
 ```
-SET feedbacks
+SET orders
 	(
-		SET accounts
-			name="new name"
-		
+		SET feedbacks
+			text="some text",
+		WHERE id="abc"
 	)
+WHERE id="order_id";
+```
 
 ## Syntax
 

--- a/dml/README.md
+++ b/dml/README.md
@@ -342,6 +342,7 @@ If you followed all steps, then the final object is:
 		}
 	}
 }
+```
 
 See more examples below:
 

--- a/dml/README.md
+++ b/dml/README.md
@@ -12,6 +12,339 @@ primarily for three reasons:
 2. The ability to funnel data change events from different sources into a common language that allows for ease de-duplication and other optimizations.
 3. Separate higher level business logic (mostly data transformation) from lower level storage modifications.
 
+## Concepts
+
+The DML works on top of the document-based data abstraction, which means
+data is represented as an hierarchical data structure (like a JSON) and
+then DML operations change internal parts of the documents.
+The user doesn't need to know the details of the storage engine, if data
+is stored as tables or files on disk, it doesn't matter and the only
+surfacing concept is that documents are hierarchical and its constituint
+parts are a subset of the JSON spec:
+
+Primitive types:
+- Number
+- String
+- Boolean
+
+**NOTE: `null` is not supported, use DELETE operations for that**
+
+Collection types:
+- Array
+- Object
+
+Given that, let's say you have an entity called `operating_systems` which is defined as:
+
+```json
+{
+	(name): (operating_system),
+}
+```
+
+and `operating_system` has schema below:
+```json
+{
+	"name": (string, pk=true),
+	"description": (string, optional=true),
+	"released_at": (date),
+	"languages": [(string, set=true)], // a "set" means it has unique elements
+	"authors": {
+		(string): (author)
+	}
+}
+```
+Note that `authors` is not an array because we don't want duplicates, so author `name` is the primary key of this related entity.
+ 
+Then schemas above means `operating_systems` is a map of `name` *->* `operating_system`.
+The `author` has the schema below:
+```json
+{
+	"id": (string, pk=true),
+	"name": (string),
+	"country": (string, optional=true)
+}
+```
+
+Given the above, let's say we have this entity persisted with just the data below:
+
+```json
+{
+	"EDSAC": {
+		"name": "edsac",
+		"languages": ["assembly"],
+		"released_at": "1949-05-06",
+		"authors": {
+			"maurice-wilkes": {
+				"id": "maurice-wilkes",
+				"name": "Maurice Wilkes",
+				"country": "United Kingdom"
+			}
+		}
+	}
+}
+```
+
+and user wants to update the _description_ that was not initially saved, then the DML statement
+below can be used:
+
+```sql
+SET operating_systems
+	description = "The Electronic Delay Storage Automatic Calculator (EDSAC) was an early British computer. Inspired by John von Neumann's seminal First Draft of a Report on the EDVAC, the machine was constructed by Maurice Wilkes and his team at the University of Cambridge Mathematical Laboratory in England to provide a service to the university.",
+WHERE
+	name="edsac";
+```
+
+Notice that `WHERE` clauses *must* address all fields marked as `pk` in the schema.
+
+The current object is:
+```json
+{
+	"edsac": {
+		"name": "edsac",
+		"description": "The Electronic Delay Storage Automatic Calculator (EDSAC) was an early British computer. Inspired by John von Neumann's seminal First Draft of a Report on the EDVAC, the machine was constructed by Maurice Wilkes and his team at the University of Cambridge Mathematical Laboratory in England to provide a service to the university.",
+		"languages": ["assembly"],
+		"released_at": "1949-05-06",
+		"authors": {
+			"maurice-wilkes": {
+				"id": "maurice-wilkes",
+				"name": "Maurice Wilkes",
+				"country": "United Kingdom"
+			}
+		}
+	}
+}
+```
+
+Now let's say you want to add new operating systems, you can set whole objects at once with the `dot-assign` syntax, like the example below:
+
+```
+SET operating_systems
+	.={
+		"name": "plan9",
+		"description": "Plan 9 from Bell Labs is an operating system designed by the Computing Science Research Center (CSRC) at Bell Labs in the mid-1980s, built on the UNIX concepts first developed there in the late 1960s. Since 2000, Plan 9 has been free and open-source. The final official release was in early 2015.",
+		"languages": ["C"],
+		"released_at": "1992-09-21",
+		"authors": {
+			"rob-pike": {
+				"id": "rob-pike",
+				"name": "Rob Pike",
+				"country": "United States"
+			},
+			"ken-thompson": {
+				"id": "ken-thompson",
+				"name": "Ken Thompson",
+				"country": "United States"
+			},
+			"dave-presotto": {
+				"id": "dave-presotto",
+				"name": "Dave Presotto",
+				"country": "United States"
+			},
+			"phil-winterbottom": {
+				"id": "phil-winterbottom",
+				"name":"Phil Winterbotton"
+			}
+		}
+	}
+WHERE name="plan9";
+```
+
+The reason that we do a `SET` for both *inserting* and *updating* is because all DML statements
+are *idempotent* and this is a very important property of the Birdie data change events.
+
+Once statement above executes, the persisted entity will be:
+
+```json
+{
+	"edsac": {
+		"name": "edsac",
+		"description": "The Electronic Delay Storage Automatic Calculator (EDSAC) was an early British computer. Inspired by John von Neumann's seminal First Draft of a Report on the EDVAC, the machine was constructed by Maurice Wilkes and his team at the University of Cambridge Mathematical Laboratory in England to provide a service to the university.",
+		"languages": ["assembly"],
+		"released_at": "1949-05-06",
+		"authors": {
+			"maurice-wilkes": {
+				"id": "maurice-wilkes",
+				"name": "Maurice Wilkes",
+				"country": "United Kingdom"
+			}
+		}
+	},
+	"plan9": {
+		"name": "plan9",
+		"description": "Plan 9 from Bell Labs is an operating system designed by the Computing Science Research Center (CSRC) at Bell Labs in the mid-1980s, built on the UNIX concepts first developed there in the late 1960s. Since 2000, Plan 9 has been free and open-source. The final official release was in early 2015.",
+		"languages": ["C"],
+		"released_at": "1992-09-21",
+		"authors": {
+			"rob-pike": {
+				"id": "rob-pike",
+				"name": "Rob Pike",
+				"country": "United States"
+			},
+			"ken-thompson": {
+				"id": "ken-thompson",
+				"name": "Ken Thompson",
+				"country": "United States"
+			},
+			"dave-presotto": {
+				"id": "dave-presotto",
+				"name": "Dave Presotto",
+				"country": "United States"
+			},
+			"phil-winterbottom": {
+				"id": "phil-winterbottom",
+				"name":"Phil Winterbotton"
+			}
+		}
+	}
+}
+```
+
+If you are an afficionado about UNIX/Bell-Labs/Plan9 history you should notice an error in the
+data above: Rob Pike was born in Canada...
+
+To fix that, we have to fix an entry inside the nested "authors" entity, and for that we have to introduce the concept of *nested DML statements*. 
+
+```sql
+SET operating_systems
+	(
+		SET authors country="Canada" WHERE name="rob-pike"
+	)
+WHERE name="plan9";
+```
+
+The *stmt* is recursive and children statement works inside the relationships.
+This way its `WHERE` clauses are clear and **unambiguous**.
+
+The final object must be:
+```json
+{
+	"edsac": {
+		"name": "edsac",
+		"description": "The Electronic Delay Storage Automatic Calculator (EDSAC) was an early British computer. Inspired by John von Neumann's seminal First Draft of a Report on the EDVAC, the machine was constructed by Maurice Wilkes and his team at the University of Cambridge Mathematical Laboratory in England to provide a service to the university.",
+		"languages": ["assembly"],
+		"released_at": "1949-05-06",
+		"authors": {
+			"maurice-wilkes": {
+				"id": "maurice-wilkes",
+				"name": "Maurice Wilkes",
+				"country": "United Kingdom"
+			}
+		}
+	},
+	"plan9": {
+		"name": "plan9",
+		"description": "Plan 9 from Bell Labs is an operating system designed by the Computing Science Research Center (CSRC) at Bell Labs in the mid-1980s, built on the UNIX concepts first developed there in the late 1960s. Since 2000, Plan 9 has been free and open-source. The final official release was in early 2015.",
+		"languages": ["C"],
+		"released_at": "1992-09-21",
+		"authors": {
+			"rob-pike": {
+				"id": "rob-pike",
+				"name": "Rob Pike",
+				"country": "United States"
+			},
+			"ken-thompson": {
+				"id": "ken-thompson",
+				"name": "Ken Thompson",
+				"country": "United States"
+			},
+			"dave-presotto": {
+				"id": "dave-presotto",
+				"name": "Dave Presotto",
+				"country": "United States"
+			},
+			"phil-winterbottom": {
+				"id": "phil-winterbottom",
+				"name":"Phil Winterbotton"
+			}
+		}
+	}
+}
+```
+
+As we all know, _Russ Cox_ had an important role in the evolution of _Plan9_, then it's fair to
+add him to the authors. Additionally, we know that Plan9 also has parts of the kernel written
+in assembly, so let's append it to the languages *set* as well:
+
+```
+SET operating_systems
+	languages=...["assembly"],
+	"authors.russ-cox"={
+		"id": "russ-cox",
+		"name": "Russ Cox",
+		"country": "United States"
+	}
+WHERE name="plan9";
+```
+
+Alternatively, the statement above can be expressed as:
+```
+SET operating_systems
+	languages=...["assembly"],
+	(
+		SET authors
+			.={
+				"id": "russ-cox",
+				"name": "Russ Cox",
+				"country": "United States"
+			}
+		WHERE id="russ-cox"
+	}
+WHERE name="plan9";
+```
+
+If you followed all steps, then the final object is:
+
+```json
+{
+	"edsac": {
+		"name": "edsac",
+		"description": "The Electronic Delay Storage Automatic Calculator (EDSAC) was an early British computer. Inspired by John von Neumann's seminal First Draft of a Report on the EDVAC, the machine was constructed by Maurice Wilkes and his team at the University of Cambridge Mathematical Laboratory in England to provide a service to the university.",
+		"languages": ["assembly"],
+		"released_at": "1949-05-06",
+		"authors": {
+			"maurice-wilkes": {
+				"id": "maurice-wilkes",
+				"name": "Maurice Wilkes",
+				"country": "United Kingdom"
+			}
+		}
+	},
+	"plan9": {
+		"name": "plan9",
+		"description": "Plan 9 from Bell Labs is an operating system designed by the Computing Science Research Center (CSRC) at Bell Labs in the mid-1980s, built on the UNIX concepts first developed there in the late 1960s. Since 2000, Plan 9 has been free and open-source. The final official release was in early 2015.",
+		"languages": ["assembly", "C"],
+		"released_at": "1992-09-21",
+		"authors": {
+			"rob-pike": {
+				"id": "rob-pike",
+				"name": "Rob Pike",
+				"country": "United States"
+			},
+			"ken-thompson": {
+				"id": "ken-thompson",
+				"name": "Ken Thompson",
+				"country": "United States"
+			},
+			"dave-presotto": {
+				"id": "dave-presotto",
+				"name": "Dave Presotto",
+				"country": "United States"
+			},
+			"phil-winterbottom": {
+				"id": "phil-winterbottom",
+				"name":"Phil Winterbotton"
+			},
+			"russ-cox": {
+				"id": "russ-cox",
+				"name": "Russ Cox",
+				"country": "United States"
+			}
+		}
+	}
+}
+
+See more examples below:
+
 ## Examples
 
 ### Update data
@@ -141,6 +474,18 @@ DELETE conversations
 	labels[_] as l : l="label-1",
 WHERE id="abc";
 ```
+
+## Nested Stmts
+
+In high-level terms, an entity is usually an array of documents.
+
+```
+SET feedbacks
+	(
+		SET accounts
+			name="new name"
+		
+	)
 
 ## Syntax
 

--- a/dml/README.md
+++ b/dml/README.md
@@ -500,16 +500,19 @@ validate the syntax definition by providing good/bad examples.
 dml {
   Stmts = 
     Stmt*
-
+    
   Stmt =
-    SetStmt   -- setstmt
-    | DelStmt -- delstmt
+  	DMLExpr ";"
+    
+  DMLExpr = 
+  	SetExpr
+    | DelExpr
 
-  SetStmt = 
-    Set ident AssignList Where Condition ";"
+  SetExpr = 
+    Set ident AssignList Where Condition
 
-  DelStmt =
-    Delete ident DeleteFilter? Where Condition ";"
+  DelExpr =
+    Delete ident DeleteFilter? Where Condition
 
   Set = 
     caseInsensitive<"SET">
@@ -530,7 +533,13 @@ dml {
     Assign ("," AssignList)?
 
   Assign = 
-    LFS "=" RFS
+    NamedAssign | NestedStmt
+    
+  NamedAssign =
+  	LFS "=" RFS
+    
+  NestedStmt = 
+  	"(" DMLExpr ")"
     
   DeleteFilter =
   	LFS (KeyDecl VarDecl? ":" Condition)?

--- a/dml/README.md
+++ b/dml/README.md
@@ -142,7 +142,7 @@ SET operating_systems
 			},
 			"phil-winterbottom": {
 				"id": "phil-winterbottom",
-				"name":"Phil Winterbotton"
+				"name": "Phil Winterbotton"
 			}
 		}
 	}
@@ -192,7 +192,7 @@ Once statement above executes, the persisted entity will be:
 			},
 			"phil-winterbottom": {
 				"id": "phil-winterbottom",
-				"name":"Phil Winterbotton"
+				"name": "Phil Winterbotton"
 			}
 		}
 	}
@@ -254,7 +254,7 @@ The final object must be:
 			},
 			"phil-winterbottom": {
 				"id": "phil-winterbottom",
-				"name":"Phil Winterbotton"
+				"name": "Phil Winterbotton"
 			}
 		}
 	}
@@ -332,7 +332,7 @@ If you followed all steps, then the final object is:
 			},
 			"phil-winterbottom": {
 				"id": "phil-winterbottom",
-				"name":"Phil Winterbotton"
+				"name": "Phil Winterbotton"
 			},
 			"russ-cox": {
 				"id": "russ-cox",

--- a/dml/README.md
+++ b/dml/README.md
@@ -207,7 +207,7 @@ To fix that, we have to fix an entry inside the nested "authors" entity, and for
 ```sql
 SET operating_systems
 	(
-		SET authors country="Canada" WHERE name="rob-pike"
+		SET authors country="Canada" WHERE id="rob-pike"
 	)
 WHERE name="plan9";
 ```

--- a/dml/ast.go
+++ b/dml/ast.go
@@ -9,10 +9,13 @@ type (
 	// Stmt is a single dml statement.
 	// A statement manipulates fields of a single entity row.
 	// The [Stmt.Assign] assigns data manipulation operations to individual fields.
+	// The [Stmt.Inner] are data manipulations in the inner relationships of the outer entity.
+	// All stmts in the [Stmt.Inner] are restricted by the `WHERE` clause in the outer stmt.
 	Stmt struct {
 		Entity unique.Handle[string]
 		Op     OpKind
 		Assign Assign
+		Inner  Stmts
 		Where  Where
 	}
 

--- a/dml/encoder.go
+++ b/dml/encoder.go
@@ -104,9 +104,17 @@ func encodeStmtExpr(w io.Writer, stmt Stmt) error {
 	if err != nil {
 		return err
 	}
-	err = encodeAssign(w, stmt.Op, stmt.Assign)
-	if err != nil {
-		return err
+	if len(stmt.Assign) > 0 {
+		err = encodeAssign(w, stmt.Op, stmt.Assign)
+		if err != nil {
+			return err
+		}
+		if len(stmt.Inner) > 0 {
+			err = write(w, ",")
+			if err != nil {
+				return err
+			}
+		}
 	}
 	for i, inner := range stmt.Inner {
 		err = write(w, "(")

--- a/dml/encoder.go
+++ b/dml/encoder.go
@@ -62,7 +62,8 @@ func validate(stmt Stmt) error {
 	if stmt.Entity != empty && !isIdent(stmt.Entity.Value()) {
 		errs = append(errs, fmt.Errorf("invalid entity %s: %w", stmt.Entity.Value(), ErrNotIdent))
 	}
-	if len(stmt.Assign) == 0 && stmt.Op != DELETE {
+	assignLen := len(stmt.Assign) + len(stmt.Inner)
+	if assignLen == 0 && stmt.Op != DELETE {
 		errs = append(errs, ErrMissingAssign)
 	}
 	keys := slices.Sorted(maps.Keys(stmt.Assign))
@@ -76,7 +77,7 @@ func validate(stmt Stmt) error {
 			errs = append(errs, v.validate())
 		}
 	}
-	if hasdot && len(stmt.Assign) > 1 {
+	if hasdot && assignLen > 1 {
 		errs = append(errs, ErrInvalidDotAssign)
 	}
 	if len(stmt.Where) == 0 {
@@ -87,7 +88,9 @@ func validate(stmt Stmt) error {
 			errs = append(errs, fmt.Errorf("clause with invalid field %s: %w", k, ErrNotIdent))
 		}
 	}
-
+	for _, innerStmt := range stmt.Inner {
+		errs = append(errs, validate(innerStmt))
+	}
 	// other validations happens at encoding phase.
 	return errors.Join(errs...)
 }
@@ -100,6 +103,26 @@ func encode(w io.Writer, stmt Stmt) error {
 	err = encodeAssign(w, stmt.Op, stmt.Assign)
 	if err != nil {
 		return err
+	}
+	for i, inner := range stmt.Inner {
+		err = write(w, "(")
+		if err != nil {
+			return err
+		}
+		err = encode(w, inner)
+		if err != nil {
+			return err
+		}
+		err = write(w, ")")
+		if err != nil {
+			return err
+		}
+		if i+1 < len(stmt.Inner) {
+			err = write(w, ",")
+			if err != nil {
+				return err
+			}
+		}
 	}
 	err = write(w, " WHERE ")
 	if err != nil {

--- a/dml/encoder.go
+++ b/dml/encoder.go
@@ -40,7 +40,11 @@ func Encode(w io.Writer, stmts Stmts) error {
 		if err != nil {
 			return err
 		}
-		err = encode(w, stmt)
+		err = encodeStmtExpr(w, stmt)
+		if err != nil {
+			return err
+		}
+		err = write(w, ";")
 		if err != nil {
 			return err
 		}
@@ -95,7 +99,7 @@ func validate(stmt Stmt) error {
 	return errors.Join(errs...)
 }
 
-func encode(w io.Writer, stmt Stmt) error {
+func encodeStmtExpr(w io.Writer, stmt Stmt) error {
 	err := encodePreamble(w, stmt)
 	if err != nil {
 		return err
@@ -109,7 +113,7 @@ func encode(w io.Writer, stmt Stmt) error {
 		if err != nil {
 			return err
 		}
-		err = encode(w, inner)
+		err = encodeStmtExpr(w, inner)
 		if err != nil {
 			return err
 		}
@@ -132,7 +136,7 @@ func encode(w io.Writer, stmt Stmt) error {
 	if err != nil {
 		return err
 	}
-	return write(w, ";")
+	return nil
 }
 
 func encodePreamble(w io.Writer, stmt Stmt) error {

--- a/dml/encoder_test.go
+++ b/dml/encoder_test.go
@@ -571,7 +571,32 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks d=1,i.j.k=...[1,2,3],s.t.r.a=["a","b","c"]... WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 		{
-			name: "append of floats",
+			name: "stmt with single inner stmt",
+			ast: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("orders"),
+					Inner: dml.Stmts{
+						{
+							Op:     dml.SET,
+							Entity: u("feedbacks"),
+							Assign: dml.Assign{
+								"text": "test",
+							},
+							Where: dml.Where{
+								"id": "abc",
+							},
+						},
+					},
+					Where: dml.Where{
+						"id": "order_id",
+					},
+				},
+			},
+			want: `SET orders (SET feedbacks text="test" WHERE id="abc") WHERE id="order_id";`,
+		},
+		{
+			name: "append missing values",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -588,7 +613,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrMissingArrayValues,
 		},
 		{
-			name: "prepend using path traversal",
+			name: "prepend missing values",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,

--- a/dml/encoder_test.go
+++ b/dml/encoder_test.go
@@ -596,6 +596,44 @@ func TestEncode(t *testing.T) {
 			want: `SET orders (SET feedbacks text="test" WHERE id="abc") WHERE id="order_id";`,
 		},
 		{
+			name: "stmt with mixed assign and inner stmts",
+			ast: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("orders"),
+					Assign: dml.Assign{
+						"name": "test",
+					},
+					Inner: dml.Stmts{
+						{
+							Op:     dml.SET,
+							Entity: u("feedbacks"),
+							Assign: dml.Assign{
+								"text": "test",
+							},
+							Where: dml.Where{
+								"id": "abc",
+							},
+						},
+						{
+							Op:     dml.SET,
+							Entity: u("feedbacks"),
+							Assign: dml.Assign{
+								"text2": "test",
+							},
+							Where: dml.Where{
+								"id": "abc2",
+							},
+						},
+					},
+					Where: dml.Where{
+						"id": "order_id",
+					},
+				},
+			},
+			want: `SET orders name="test",(SET feedbacks text="test" WHERE id="abc"),(SET feedbacks text2="test" WHERE id="abc2") WHERE id="order_id";`,
+		},
+		{
 			name: "append missing values",
 			ast: dml.Stmts{
 				{

--- a/dml/encoder_test.go
+++ b/dml/encoder_test.go
@@ -14,6 +14,7 @@ import (
 func TestEncode(t *testing.T) {
 	t.Parallel()
 	type testcase struct {
+		name string
 		ast  dml.Stmts
 		want string
 		err  error
@@ -21,48 +22,102 @@ func TestEncode(t *testing.T) {
 
 	for _, tc := range []testcase{
 		{
+			name: "list of errors must contain dml.ErrInvalidOperation",
 			ast: dml.Stmts{
 				{},
 			},
 			err: dml.ErrInvalidOperation,
 		},
 		{
+			name: "list of errors must contain dml.ErrMissingAssign",
 			ast: dml.Stmts{
 				{},
 			},
 			err: dml.ErrMissingAssign,
 		},
 		{
+			name: "list of errors must contain dml.ErrMissingEntity",
 			ast: dml.Stmts{
 				{},
 			},
 			err: dml.ErrMissingEntity,
 		},
 		{
+			name: "list of errors must contain dml.ErrMissingWhere",
 			ast: dml.Stmts{
 				{},
 			},
 			err: dml.ErrMissingWhereClause,
 		},
 		{
+			name: "list of errors must contain dml.ErrMissingEntity",
 			ast: dml.Stmts{
 				{Op: dml.SET},
 			},
 			err: dml.ErrMissingEntity,
 		},
 		{
-			ast: dml.Stmts{
-				{Op: dml.SET, Entity: u("test")},
-			},
-			err: dml.ErrMissingAssign,
-		},
-		{
+			name: "missing WHERE clause",
 			ast: dml.Stmts{
 				{Op: dml.SET, Entity: u("test"), Assign: dml.Assign{".": map[string]any{}}},
 			},
 			err: dml.ErrMissingWhereClause,
 		},
+		// inner validations
 		{
+			name: "inner stmts missing lots of fields - must report dml.ErrInvalidOperation",
+			ast: dml.Stmts{
+				{
+					Entity: u("something"),
+					Inner: dml.Stmts{
+						{},
+					},
+					Where: dml.Where{"id": "test"},
+				},
+			},
+			err: dml.ErrInvalidOperation,
+		},
+		{
+			name: "inner stmts missing lots of fields - must report dml.ErrMissingAssign",
+			ast: dml.Stmts{
+				{
+					Entity: u("something"),
+					Inner: dml.Stmts{
+						{},
+					},
+					Where: dml.Where{"id": "test"},
+				},
+			},
+			err: dml.ErrMissingAssign,
+		},
+		{
+			name: "inner stmts missing lots of fields - must report dml.ErrMissingEntity",
+			ast: dml.Stmts{
+				{
+					Entity: u("something"),
+					Inner: dml.Stmts{
+						{},
+					},
+					Where: dml.Where{"id": "test"},
+				},
+			},
+			err: dml.ErrMissingEntity,
+		},
+		{
+			name: "inner stmts missing lots of fields - must report dml.ErrMissingWhereClause",
+			ast: dml.Stmts{
+				{
+					Entity: u("something"),
+					Inner: dml.Stmts{
+						{},
+					},
+					Where: dml.Where{"id": "test"},
+				},
+			},
+			err: dml.ErrMissingWhereClause,
+		},
+		{
+			name: "invalid assign key",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -76,6 +131,30 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrInvalidAssignKey,
 		},
 		{
+			name: "inner stmt with invalid assign key",
+			ast: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("test"),
+					Inner: dml.Stmts{
+						{
+							Op:     dml.SET,
+							Entity: u("other"),
+							Assign: dml.Assign{"$a": map[string]any{}},
+							Where: dml.Where{
+								"id": "other",
+							},
+						},
+					},
+					Where: dml.Where{
+						"id": "abc",
+					},
+				},
+			},
+			err: dml.ErrInvalidAssignKey,
+		},
+		{
+			name: "invalid entity name",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -89,6 +168,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrNotIdent,
 		},
 		{
+			name: "invalid ident in where",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -102,6 +182,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrNotIdent,
 		},
 		{
+			name: "invalid path traversal",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -115,6 +196,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrInvalidAssignKey,
 		},
 		{
+			name: " invalid assign quoted path traversal",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -128,6 +210,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrInvalidAssignKey,
 		},
 		{
+			name: "single-quote path traversal is not valid",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -141,6 +224,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrInvalidAssignKey,
 		},
 		{
+			name: "invalid quoted base key",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -154,6 +238,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrInvalidAssignKey,
 		},
 		{
+			name: "invalid assign key - required ident",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -167,6 +252,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrInvalidAssignKey,
 		},
 		{
+			name: "invalid assign key - required ident",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -180,6 +266,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrInvalidAssignKey,
 		},
 		{
+			name: "invalid assign key - required ident",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -193,6 +280,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrInvalidAssignKey,
 		},
 		{
+			name: "valid stmt using assign of numbers",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -206,6 +294,7 @@ func TestEncode(t *testing.T) {
 			want: "SET feedbacks a=1 WHERE id=1;",
 		},
 		{
+			name: "valid stmt using assign of booleans",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -219,6 +308,7 @@ func TestEncode(t *testing.T) {
 			want: "SET feedbacks a=false WHERE id=false;",
 		},
 		{
+			name: "valid stmt using assign of objects",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -232,6 +322,7 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks a={"k1":"v1","k2":"v2"} WHERE id="abc";`,
 		},
 		{
+			name: "valid stmt using assign of arrays",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -247,6 +338,7 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks a.b.c=["a","b","c"] WHERE id="abc";`,
 		},
 		{
+			name: "valid stmt using multiple assigns",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -263,6 +355,7 @@ func TestEncode(t *testing.T) {
 			want: `SET organizations config={},name="some org" WHERE id="abc";`,
 		},
 		{
+			name: "valid dot-assign",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -281,6 +374,7 @@ func TestEncode(t *testing.T) {
 			want: `SET organizations .={"name":"some org","test":"abc"} WHERE id="abc";`,
 		},
 		{
+			name: "it's invalid to merge dot-assign with normal assign",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -300,6 +394,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrInvalidDotAssign,
 		},
 		{
+			name: "multiple stmts",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -322,6 +417,7 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks a=1 WHERE id=1;SET organizations abc=1 WHERE id="abc";`,
 		},
 		{
+			name: "assign of dashed keys",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -335,6 +431,7 @@ func TestEncode(t *testing.T) {
 			want: "SET feedbacks some-field=1 WHERE id=1;",
 		},
 		{
+			name: "assign of dashed keys in path traversal",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -348,6 +445,7 @@ func TestEncode(t *testing.T) {
 			want: "SET feedbacks abc.some-field=1 WHERE id=1;",
 		},
 		{
+			name: "assign of base dashed path traversal",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -361,6 +459,7 @@ func TestEncode(t *testing.T) {
 			want: "SET feedbacks some-field.some-other-field=1 WHERE id=1;",
 		},
 		{
+			name: "assign of path traversal containing quoted string components",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -374,6 +473,7 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks a."some_field"=1 WHERE id=1;`,
 		},
 		{
+			name: "assign of quoted string containing advanced symbols",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -387,6 +487,7 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks a."some-other-field"=1 WHERE id=1;`,
 		},
 		{
+			name: "combining multiple quoted strings in path traversal",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -400,6 +501,7 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks a."some field".test."other field"=1 WHERE id=1;`,
 		},
 		{
+			name: "multiple predicates in AND clause",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -416,6 +518,7 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks a.b.c=["a","b","c"] WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 		{
+			name: "append of values list",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -432,6 +535,7 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks a.b.c=...["a","b","c"] WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 		{
+			name: "prepend of values list",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -448,6 +552,7 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks a.b.c=["a","b","c"]... WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 		{
+			name: "multiple assigns containing append and prepend",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -466,6 +571,7 @@ func TestEncode(t *testing.T) {
 			want: `SET feedbacks d=1,i.j.k=...[1,2,3],s.t.r.a=["a","b","c"]... WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 		{
+			name: "append of floats",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -482,6 +588,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrMissingArrayValues,
 		},
 		{
+			name: "prepend using path traversal",
 			ast: dml.Stmts{
 				{
 					Op:     dml.SET,
@@ -498,6 +605,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrMissingArrayValues,
 		},
 		{
+			name: " delete requires only 1 assign",
 			ast: dml.Stmts{
 				{
 					Op:     dml.DELETE,
@@ -515,6 +623,7 @@ func TestEncode(t *testing.T) {
 			err: dml.ErrInvalidDotAssign,
 		},
 		{
+			name: "delete by key filter",
 			ast: dml.Stmts{
 				{
 					Op:     dml.DELETE,
@@ -531,6 +640,7 @@ func TestEncode(t *testing.T) {
 			want: `DELETE feedbacks obj[k] : k="a" WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 		{
+			name: "delete by multiple keys",
 			ast: dml.Stmts{
 				{
 					Op:     dml.DELETE,
@@ -547,6 +657,7 @@ func TestEncode(t *testing.T) {
 			want: `DELETE feedbacks obj[k] : k IN ["a","b"] WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 		{
+			name: "delete by value",
 			ast: dml.Stmts{
 				{
 					Op:     dml.DELETE,
@@ -563,6 +674,7 @@ func TestEncode(t *testing.T) {
 			want: `DELETE feedbacks labels[_] => v : v="label-1" WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 		{
+			name: "delete by multiple values",
 			ast: dml.Stmts{
 				{
 					Op:     dml.DELETE,
@@ -579,6 +691,7 @@ func TestEncode(t *testing.T) {
 			want: `DELETE feedbacks labels[_] => v : v IN ["label-1","label-2"] WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 		{
+			name: "delete by key and value",
 			ast: dml.Stmts{
 				{
 					Op:     dml.DELETE,
@@ -595,6 +708,7 @@ func TestEncode(t *testing.T) {
 			want: `DELETE feedbacks custom_fields[k] => v : k="country" AND v="us" WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 		{
+			name: "multiple delete assignments",
 			ast: dml.Stmts{
 				{
 					Op:     dml.DELETE,
@@ -612,26 +726,28 @@ func TestEncode(t *testing.T) {
 			want: `DELETE feedbacks a.b[k] : k="test",a.b.c[k] => v : k="country" AND v="us" WHERE {"id":"abc","org_id":"xyz"};`,
 		},
 	} {
-		var buf bytes.Buffer
-		err := dml.Encode(&buf, tc.ast)
-		if !errors.Is(err, tc.err) {
-			t.Fatal(err)
-		}
-		if err != nil {
-			continue
-		}
-		got := buf.String()
-		if diff := cmp.Diff(tc.want, got); diff != "" {
-			t.Log(tc.want)
-			t.Fatalf("got [+], want [-]: %s", diff)
-		}
-		decoded, err := dml.Parse([]byte(got))
-		if err != nil {
-			t.Fatalf("failed to decoded the encoded buffer [%s]: %v", tc.want, err)
-		}
-		if diff := cmp.Diff(decoded, tc.ast, cmpopts.EquateComparable(unique.Handle[string]{})); diff != "" {
-			t.Fatalf("encode/decode of [%s], got diff: %s", tc.want, diff)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := dml.Encode(&buf, tc.ast)
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("error mismatch: expected [%v] but got [%v]", tc.err, err)
+			}
+			if err != nil {
+				return
+			}
+			got := buf.String()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Log(tc.want)
+				t.Fatalf("got [+], want [-]: %s", diff)
+			}
+			decoded, err := dml.Parse([]byte(got))
+			if err != nil {
+				t.Fatalf("failed to decoded the encoded buffer [%s]: %v", tc.want, err)
+			}
+			if diff := cmp.Diff(decoded, tc.ast, cmpopts.EquateComparable(unique.Handle[string]{})); diff != "" {
+				t.Fatalf("encode/decode of [%s], got diff: %s", tc.want, diff)
+			}
+		})
 	}
 }
 

--- a/dml/parser.go
+++ b/dml/parser.go
@@ -155,19 +155,29 @@ func parseSetAssigns(in []byte) (Assign, Stmts, []byte, error) {
 			if in[0] != ')' {
 				return nil, nil, nil, fmt.Errorf("%w: inner stmt missing closing ')'", ErrSyntax)
 			}
-			in = in[1:]
+			in = skipblank(in[1:])
+			if len(in) == 0 {
+				return nil, nil, nil, errUnexpectedEOF()
+			}
 			inner = append(inner, stmt)
-			continue
+			if in[0] == ',' {
+				in = in[1:]
+				continue
+			}
+			if len(assign) == 0 {
+				assign = nil
+			}
+			return assign, inner, in, nil
 		}
 		key, val, in, err = parseAssign(in)
 		if err != nil {
-			return Assign{}, nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		assign[key] = val
 		in = skipblank(in)
 		if len(in) == 0 {
-			return Assign{}, nil, nil, errUnexpectedEOF()
+			return nil, nil, nil, errUnexpectedEOF()
 		}
 		if in[0] == ',' {
 			// only one "." assign
@@ -256,7 +266,7 @@ func parseAssign(in []byte) (string, any, []byte, error) {
 		return "", nil, nil, errUnexpectedEOF()
 	}
 	if in[0] != '=' {
-		return "", nil, nil, fmt.Errorf("%w: expected 'b='", ErrSyntax)
+		return "", nil, nil, fmt.Errorf("%w: expected '=' but got '%s'", ErrSyntax, in[:])
 	}
 	in = skipblank(in[1:])
 	if len(in) == 0 {

--- a/dml/parser.go
+++ b/dml/parser.go
@@ -33,9 +33,6 @@ func Parse(in []byte) (Stmts, error) {
 		if err == errEOF {
 			break
 		}
-		if err == errEOF {
-			break
-		}
 		if err != nil {
 			return nil, err
 		}

--- a/dml/parser.go
+++ b/dml/parser.go
@@ -33,6 +33,9 @@ func Parse(in []byte) (Stmts, error) {
 		if err == errEOF {
 			break
 		}
+		if err == errEOF {
+			break
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -46,6 +49,22 @@ func Parse(in []byte) (Stmts, error) {
 }
 
 func parseStmt(in []byte) (Stmt, []byte, error) {
+	stmt, in, err := parseStmtExpr(in)
+	if err != nil {
+		return Stmt{}, nil, err
+	}
+	in = skipblank(in)
+	if len(in) == 0 {
+		return Stmt{}, nil, errUnexpectedEOF()
+	}
+	if in[0] != ';' {
+		return Stmt{}, nil, ErrSyntax
+	}
+	in = in[1:]
+	return stmt, in, nil
+}
+
+func parseStmtExpr(in []byte) (Stmt, []byte, error) {
 	in = skipblank(in)
 	if len(in) == 0 {
 		return Stmt{}, nil, errEOF
@@ -80,7 +99,7 @@ func parseStmt(in []byte) (Stmt, []byte, error) {
 	}
 
 	if stmt.Op == SET {
-		stmt.Assign, in, err = parseSetAssigns(in)
+		stmt.Assign, stmt.Inner, in, err = parseSetAssigns(in)
 	} else {
 		stmt.Assign, in, err = parseDelAssigns(in)
 	}
@@ -106,49 +125,64 @@ func parseStmt(in []byte) (Stmt, []byte, error) {
 	if err != nil {
 		return Stmt{}, nil, err
 	}
-	in = skipblank(in)
-	if len(in) == 0 {
-		return Stmt{}, nil, errUnexpectedEOF()
-	}
-	if in[0] != ';' {
-		return Stmt{}, nil, ErrSyntax
-	}
-	in = in[1:]
 	return stmt, in, nil
 }
 
-func parseSetAssigns(in []byte) (Assign, []byte, error) {
+// also handles inner stmts (they are like assignment in another entity)
+func parseSetAssigns(in []byte) (Assign, Stmts, []byte, error) {
 	assign := Assign{}
+	var inner Stmts
 	for len(in) > 0 {
 		var (
 			key string
 			val any
 			err error
 		)
+		in = skipblank(in)
+		if len(in) == 0 {
+			return nil, nil, nil, errUnexpectedEOF()
+		}
+		if in[0] == '(' {
+			var stmt Stmt
+			stmt, in, err = parseStmtExpr(in[1:])
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			in = skipblank(in)
+			if len(in) == 0 {
+				return nil, nil, nil, errUnexpectedEOF()
+			}
+			if in[0] != ')' {
+				return nil, nil, nil, fmt.Errorf("%w: inner stmt missing closing ')'", ErrSyntax)
+			}
+			in = in[1:]
+			inner = append(inner, stmt)
+			continue
+		}
 		key, val, in, err = parseAssign(in)
 		if err != nil {
-			return Assign{}, nil, err
+			return Assign{}, nil, nil, err
 		}
 
 		assign[key] = val
 		in = skipblank(in)
 		if len(in) == 0 {
-			return Assign{}, nil, errUnexpectedEOF()
+			return Assign{}, nil, nil, errUnexpectedEOF()
 		}
 		if in[0] == ',' {
 			// only one "." assign
 			if _, ok := assign["."]; ok {
-				return Assign{}, nil, fmt.Errorf("%w: only one '.' assignment is permitted. Unexpected ','", ErrSyntax)
+				return Assign{}, nil, nil, fmt.Errorf("%w: only one '.' assignment is permitted. Unexpected ','", ErrSyntax)
 			}
 			in = skipblank(in[1:])
 			if len(in) == 0 {
-				return Assign{}, nil, errUnexpectedEOF()
+				return Assign{}, nil, nil, errUnexpectedEOF()
 			}
 			continue
 		}
 		break
 	}
-	return assign, in, nil
+	return assign, inner, in, nil
 }
 
 func parseDelAssigns(in []byte) (Assign, []byte, error) {
@@ -189,7 +223,7 @@ func parseAssign(in []byte) (string, any, []byte, error) {
 			return "", nil, nil, errUnexpectedEOF()
 		}
 		if in[0] != '=' {
-			return "", nil, nil, fmt.Errorf("%w: expected '=' token", ErrSyntax)
+			return "", nil, nil, fmt.Errorf("%w: expected 'a=' token", ErrSyntax)
 		}
 		in = in[1:]
 		in = skipblank(in)
@@ -222,7 +256,7 @@ func parseAssign(in []byte) (string, any, []byte, error) {
 		return "", nil, nil, errUnexpectedEOF()
 	}
 	if in[0] != '=' {
-		return "", nil, nil, fmt.Errorf("%w: expected '='", ErrSyntax)
+		return "", nil, nil, fmt.Errorf("%w: expected 'b='", ErrSyntax)
 	}
 	in = skipblank(in[1:])
 	if len(in) == 0 {

--- a/dml/parser.go
+++ b/dml/parser.go
@@ -233,7 +233,7 @@ func parseAssign(in []byte) (string, any, []byte, error) {
 			return "", nil, nil, errUnexpectedEOF()
 		}
 		if in[0] != '=' {
-			return "", nil, nil, fmt.Errorf("%w: expected 'a=' token", ErrSyntax)
+			return "", nil, nil, fmt.Errorf("%w: expected '=' token", ErrSyntax)
 		}
 		in = in[1:]
 		in = skipblank(in)

--- a/dml/parser_test.go
+++ b/dml/parser_test.go
@@ -545,6 +545,108 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
+			text: `SET orders (SET feedbacks .={} WHERE id="abc") WHERE id="test";`,
+			want: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("orders"),
+					Inner: dml.Stmts{
+						{
+							Op:     dml.SET,
+							Entity: u("feedbacks"),
+							Assign: dml.Assign{
+								".": map[string]any{},
+							},
+							Where: dml.Where{
+								"id": "abc",
+							},
+						},
+					},
+					Where: dml.Where{
+						"id": "test",
+					},
+				},
+			},
+		},
+		{
+			text: `SET orders a=1,b=2,(SET feedbacks .={} WHERE id="abc"),(SET feedbacks text="test" WHERE id="abc2") WHERE id="test";`,
+			want: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("orders"),
+					Assign: dml.Assign{
+						"a": float64(1),
+						"b": float64(2),
+					},
+					Inner: dml.Stmts{
+						{
+							Op:     dml.SET,
+							Entity: u("feedbacks"),
+							Assign: dml.Assign{
+								".": map[string]any{},
+							},
+							Where: dml.Where{
+								"id": "abc",
+							},
+						},
+						{
+							Op:     dml.SET,
+							Entity: u("feedbacks"),
+							Assign: dml.Assign{
+								"text": "test",
+							},
+							Where: dml.Where{
+								"id": "abc2",
+							},
+						},
+					},
+					Where: dml.Where{
+						"id": "test",
+					},
+				},
+			},
+		},
+		{
+			noEncoderTest: true,
+			text:          `SET orders a=1,(SET feedbacks .={} WHERE id="abc"),b=2,(SET feedbacks text="test" WHERE id="abc2"),c=3 WHERE id="test";`,
+			want: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("orders"),
+					Assign: dml.Assign{
+						"a": float64(1),
+						"b": float64(2),
+						"c": float64(3),
+					},
+					Inner: dml.Stmts{
+						{
+							Op:     dml.SET,
+							Entity: u("feedbacks"),
+							Assign: dml.Assign{
+								".": map[string]any{},
+							},
+							Where: dml.Where{
+								"id": "abc",
+							},
+						},
+						{
+							Op:     dml.SET,
+							Entity: u("feedbacks"),
+							Assign: dml.Assign{
+								"text": "test",
+							},
+							Where: dml.Where{
+								"id": "abc2",
+							},
+						},
+					},
+					Where: dml.Where{
+						"id": "test",
+					},
+				},
+			},
+		},
+		{
 			text: `DELETE feedbacks . WHERE id="abc";`,
 			want: dml.Stmts{
 				{


### PR DESCRIPTION
Introduce the concept of nested DML statements.
This is needed for updating data with relationships and we found that this design has lots of benefits when compared to a special syntax for that. It makes things easier to implement, easier to reason about and easier to generate sub-stmts for our materialized view relationships in Elasticsearch.