### PR TITLE
feat: add agg LIMIT.

### DIFF
--- a/dql/parser.go
+++ b/dql/parser.go
@@ -440,6 +440,18 @@ func parseNumberExpr(l *lexer) (NumberExpr, error) {
 	return NewNumberExpr(float64(val)), nil
 }
 
+func parseInt(l *lexer) (int, error) {
+	tok, err := l.Next()
+	if err != nil {
+		return 0, err
+	}
+	val, err := strconv.Atoi(tok.Value)
+	if err != nil {
+		return 0, err
+	}
+	return val, nil
+}
+
 func parseStringExpr(l *lexer) (StringExpr, error) {
 	tok, err := l.Next()
 	if err != nil {

--- a/dql/parser_aggs.go
+++ b/dql/parser_aggs.go
@@ -55,7 +55,6 @@ func parseAgg(l *lexer) (Agg, error) {
 		return Agg{}, errUnexpectedToken(tok, `STRING | IDENT`)
 	}
 	name := tok.Value
-
 	tok, err = l.Next()
 	if err != nil {
 		return Agg{}, err
@@ -86,6 +85,10 @@ func parseAgg(l *lexer) (Agg, error) {
 		Name: name,
 		Func: fn,
 	}
+	err = parseAggOptions(l, &agg)
+	if err != nil {
+		return Agg{}, err
+	}
 	tok, err = l.Peek()
 	if err != nil {
 		return Agg{}, err
@@ -99,4 +102,31 @@ func parseAgg(l *lexer) (Agg, error) {
 		agg.Children = aggs
 	}
 	return agg, nil
+}
+
+func parseAggOptions(l *lexer, agg *Agg) error {
+	for {
+		tok, err := l.Peek()
+		if err != nil {
+			return err
+		}
+		switch tok.Type {
+		default:
+			return errUnexpectedToken(tok, `}|LIMIT|ORDER BY`)
+		case lbraceToken, rbraceToken, commaToken:
+			return nil
+		case keywordToken:
+			switch tok.Value {
+			default:
+				return errUnexpectedToken(tok, `}|LIMIT|ORDER`)
+			case "LIMIT":
+				l.Eat(1)
+				n, err := parseInt(l)
+				if err != nil {
+					return err
+				}
+				agg.Limit = &n
+			}
+		}
+	}
 }

--- a/dql/parser_aggs.go
+++ b/dql/parser_aggs.go
@@ -112,13 +112,13 @@ func parseAggOptions(l *lexer, agg *Agg) error {
 		}
 		switch tok.Type {
 		default:
-			return errUnexpectedToken(tok, `}|LIMIT|ORDER BY`)
+			return errUnexpectedToken(tok, `}|LIMIT`)
 		case lbraceToken, rbraceToken, commaToken:
 			return nil
 		case keywordToken:
 			switch tok.Value {
 			default:
-				return errUnexpectedToken(tok, `}|LIMIT|ORDER`)
+				return errUnexpectedToken(tok, `}|LIMIT`)
 			case "LIMIT":
 				l.Eat(1)
 				n, err := parseInt(l)

--- a/dql/parser_aggs_test.go
+++ b/dql/parser_aggs_test.go
@@ -43,12 +43,32 @@ func TestParserAggs(t *testing.T) {
 			},
 		},
 		{
+			name: "agg with LIMIT",
+			in: `SEARCH feedbacks AGGS {
+				by_labels: terms(labels) LIMIT 1000
+			};`,
+			out: dql.Program{
+				Stmts: dql.Stmts{
+					{
+						Entity: "feedbacks",
+						Aggs: dql.Aggs{
+							"by_labels": dql.Agg{
+								Name:  "by_labels",
+								Func:  dql.NewFncallExpr("terms", dql.NewVarExpr("labels")),
+								Limit: ptr(1000),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "multiple aggs",
 			in: `SEARCH feedbacks AGGS {
-				labels: terms("labels"),
+				labels: terms("labels") LIMIT 1,
 				"string name": date_histogram("posted_at"),
-				sample_id: terms("sample_id") {
-					nested: terms("labels")
+				sample_id: terms("sample_id") LIMIT 2 {
+					nested: terms("labels") LIMIT 3
 				},
 				by_month: date_histogram(posted_at, {"interval": "month"})
 			};`,
@@ -58,20 +78,23 @@ func TestParserAggs(t *testing.T) {
 						Entity: "feedbacks",
 						Aggs: dql.Aggs{
 							"labels": {
-								Name: "labels",
-								Func: dql.NewFncallExpr("terms", dql.NewStringExpr("labels")),
+								Name:  "labels",
+								Func:  dql.NewFncallExpr("terms", dql.NewStringExpr("labels")),
+								Limit: ptr(1),
 							},
 							"string name": {
 								Name: "string name",
 								Func: dql.NewFncallExpr("date_histogram", dql.NewStringExpr("posted_at")),
 							},
 							"sample_id": {
-								Name: "sample_id",
-								Func: dql.NewFncallExpr("terms", dql.NewStringExpr("sample_id")),
+								Name:  "sample_id",
+								Func:  dql.NewFncallExpr("terms", dql.NewStringExpr("sample_id")),
+								Limit: ptr(2),
 								Children: dql.Aggs{
 									"nested": {
-										Name: "nested",
-										Func: dql.NewFncallExpr("terms", dql.NewStringExpr("labels")),
+										Name:  "nested",
+										Func:  dql.NewFncallExpr("terms", dql.NewStringExpr("labels")),
+										Limit: ptr(3),
 									},
 								},
 							},


### PR DESCRIPTION
Implements support for adding a LIMIT to an aggregation.
Example:
```
by_label: terms(labels) LIMIT 1000
```