### PR TITLE
feat: add PAGINATE stmt operation. 

### DIFF
--- a/dql/README.md
+++ b/dql/README.md
@@ -238,7 +238,7 @@ Returns:
 
 Pagination is explicitly enabled by adding:
 ```
-LIMIT <n> WITH CURSOR
+PAGINATE
 ```
 to a `SEARCH` statement.
 
@@ -254,7 +254,7 @@ WHERE {
 	]
 }
 LIMIT 1000
-WITH CURSOR;
+PAGINATE;
 ```
 
 *Ordering rules*
@@ -263,47 +263,54 @@ Pagination requires a *stable and deterministic order*.
 
 If no order is applied, the system implicitly applies:
 ```
-ORDER BY id ASC
+ORDER BY created_at ASC, id ASC
 ```
-or whatever is the entity primary key.
 
-If an order is provided:
-- **it must be deterministic** (a *score* field must never be used).
-- **it must include the primary key** (eg.: `id`) **as the final tiebreaker**.
+If an ORDER is provided:
+- **it must** be a deterministic sortable and immutable field.
+- **the `id` is always used as tiebreaker.
 
 Example:
 ```
-ORDER BY posted_at DESC, id DESC
+ORDER BY some_immutable_field
 ```
 
-*Cursor usage*
+*Usage*
 
-The response for a paginated query includes a `next_cursor` value (format is opaque and implementation-defined).
-
-To fetch the next page, pass the cursor using the `AFTER` clause:
+Let's say your statement looks like below:
 
 ```
-SEARCH feedbacks
+AS feedback_results SEARCH feedback id, text WHERE {
+	"$and": [ ... ]
+} LIMIT 1000 PAGINATE;
+```
+
+Then the server response will include a `next` field in the form of a valid DQL like the
+one below:
+
+```
+AS feedbacks_results PAGINATE feedbacks
 	id, text, account
 WHERE {
-	"$and": [
-		{"text": "something"},
-		{"account.ingested_id": ["abc", "xyz"]}
-	]
+	"$and": [ ... ]
 }
 LIMIT 1000
-AFTER "eyJ2I...";
+ORDER BY created_at ASC, id ASC
+CONTEXT {
+	"pit": "aaAAbbBB...",
+	"after": {
+		"id": "abc",
+		"created_at": 28838282
+	}
+};
 ```
 
-*Consistency Requirements*
+The `CONTEXT ...` clause contain public details that should only be interpreted by the server,
+which means its fields can change in the future without any announcement.
 
-For pagination to be correct, the statement must remain **identical across all pages** except the
-`AFTER` clause. If changing any other information between requests is **undefined behavior** and
-the server implementation can detect such cases and give errors.
+It's in plaintext for two reasons:
+- debuggability
+- emphasize it's public data.
 
-*Behavior guarantees*
-
-- Consistent order
-
-For any other guarantees (like *no duplicates* or snapshot-based pagination under concurrent writes)
-check the server documentation.
+For retrieving the next page, you can send this statement anywhere in the payload, even
+together with other statements.

--- a/dql/ast.go
+++ b/dql/ast.go
@@ -287,3 +287,5 @@ func (s Sort) String() string {
 		return "<INVALID>"
 	}
 }
+
+func (p StaticPath) String() string { return strings.Join(p, ".") }

--- a/dql/ast.go
+++ b/dql/ast.go
@@ -274,7 +274,7 @@ func (op Predicate) String() string {
 }
 
 func (o OrderBy) String() string {
-	return strings.Join(o.Field, ".") + " " + o.Sort.String()
+	return o.Field.String() + " " + o.Sort.String()
 }
 
 func (s Sort) String() string {

--- a/dql/ast.go
+++ b/dql/ast.go
@@ -14,18 +14,24 @@ type (
 
 	// Stmt is a dql statement node.
 	Stmt struct {
-		Name       string
-		Entity     string
-		Fields     []Expr
-		Where      *QueryExpr
-		Limit      *int
-		WithCursor bool
-		After      Expr
-		OrderBy    []OrderBy
-		Aggs       Aggs
+		Name    string
+		Op      OpKind
+		Entity  string
+		Fields  []Expr
+		Where   *QueryExpr
+		Limit   *int
+		After   Expr
+		OrderBy []OrderBy
+		Aggs    Aggs
+
+		Paginate bool
+		Context  *ObjectExpr
 
 		// TODO(i4k): add Span
 	}
+
+	// OpKind is the intended operation kind: SEARCH | PAGINATE
+	OpKind string
 
 	// Stmts is a list of stmt.
 	Stmts []Stmt
@@ -222,6 +228,11 @@ const (
 	invalidStep StepType = iota
 	FieldStep
 	IndexStep
+)
+
+var (
+	SEARCH   = OpKind("SEARCH")
+	PAGINATE = OpKind("PAGINATE")
 )
 
 // IsRange tells if the predicate is a range.

--- a/dql/ast.go
+++ b/dql/ast.go
@@ -20,7 +20,6 @@ type (
 		Fields  []Expr
 		Where   *QueryExpr
 		Limit   *int
-		After   Expr
 		OrderBy []OrderBy
 		Aggs    Aggs
 

--- a/dql/ast.go
+++ b/dql/ast.go
@@ -230,6 +230,7 @@ const (
 	IndexStep
 )
 
+// statement operations.
 var (
 	SEARCH   = OpKind("SEARCH")
 	PAGINATE = OpKind("PAGINATE")

--- a/dql/encoder.go
+++ b/dql/encoder.go
@@ -119,7 +119,10 @@ func validateStmt(s Stmt) error {
 
 func (e *Encoder) stmt(s Stmt) error {
 	if s.Name != "" && !e.onlyShape {
-		e.emit("AS " + s.Name + " ")
+		err := e.emit("AS " + s.Name + " ")
+		if err != nil {
+			return err
+		}
 	}
 	err := e.preamble(s)
 	if err != nil {
@@ -150,7 +153,7 @@ func (e *Encoder) stmt(s Stmt) error {
 		}
 	}
 	if s.Paginate {
-		err := e.emit(` PAGINATE`);
+		err := e.emit(` PAGINATE`)
 		if err != nil {
 			return err
 		}
@@ -512,10 +515,16 @@ func (e *Encoder) limit(limit int) error {
 }
 
 func (e *Encoder) orderBy(orderBy []OrderBy) error {
-	e.emit(" ORDER BY ")
+	err := e.emit(" ORDER BY ")
+	if err != nil {
+		return err
+	}
 	for i, order := range orderBy {
 		if i > 0 {
-			e.emit(",")
+			err := e.emit(",")
+			if err != nil {
+				return err
+			}
 		}
 		err := e.emit(order.String())
 		if err != nil {

--- a/dql/encoder.go
+++ b/dql/encoder.go
@@ -27,6 +27,8 @@ type (
 
 // encoder errors
 var (
+	ErrMalformedStmt      = errors.New(`malformed statement node`)
+	ErrInvalidStmtOp      = errors.New(`invalid stmt operation`)
 	ErrMissingEntity      = errors.New(`missing entity`)
 	ErrUnexpectedExprType = errors.New(`expression type not expected here`)
 	ErrInvalidLogicalExpr = errors.New(`invalid logical expression`)
@@ -89,13 +91,33 @@ func (e *Encoder) Values() []Expr {
 
 func validateStmt(s Stmt) error {
 	var errs []error
+	if s.Op != SEARCH && s.Op != PAGINATE {
+		errs = append(errs, ErrInvalidStmtOp)
+	}
 	if s.Entity == "" {
 		errs = append(errs, ErrMissingEntity)
+	}
+	if s.Op != PAGINATE && s.Context != nil {
+		errs = append(errs, fmt.Errorf(`%w: only PAGINATE stmts support CONTEXT clause`, ErrMalformedStmt))
+	}
+	if s.Name != "" {
+		l := newlexer(s.Name)
+		tok, err := l.Next()
+		if err != nil {
+			errs = append(errs, fmt.Errorf("%w: validating statement name: %s", err, s.Name))
+		} else {
+			if tok.Type != identToken {
+				errs = append(errs, fmt.Errorf("statement name must be an IDENT but found %v", tok.Type))
+			}
+		}
 	}
 	return errors.Join(errs...)
 }
 
 func (e *Encoder) stmt(s Stmt) error {
+	if s.Name != "" && !e.onlyShape {
+		e.emit("AS " + s.Name + " ")
+	}
 	err := e.preamble(s)
 	if err != nil {
 		return err
@@ -117,6 +139,16 @@ func (e *Encoder) stmt(s Stmt) error {
 		if err != nil {
 			return err
 		}
+	}
+	if len(s.OrderBy) > 0 {
+		err = e.orderBy(s.OrderBy)
+		if err != nil {
+			return err
+		}
+	}
+	if s.Context != nil && !e.onlyShape {
+		e.emit(` CONTEXT `)
+		e.expr(*s.Context, false)
 	}
 	return e.emit(";")
 }
@@ -464,6 +496,20 @@ func (e *Encoder) limit(limit int) error {
 	return e.json(limit)
 }
 
+func (e *Encoder) orderBy(orderBy []OrderBy) error {
+	e.emit(" ORDER BY ")
+	for i, order := range orderBy {
+		if i > 0 {
+			e.emit(",")
+		}
+		err := e.emit(order.String())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (e *Encoder) json(v any) error {
 	data, err := json.Marshal(v)
 	if err != nil {
@@ -473,7 +519,7 @@ func (e *Encoder) json(v any) error {
 }
 
 func (e *Encoder) preamble(s Stmt) error {
-	err := e.emit("SEARCH ")
+	err := e.emit(string(s.Op) + " ")
 	if err != nil {
 		return err
 	}

--- a/dql/encoder.go
+++ b/dql/encoder.go
@@ -94,6 +94,9 @@ func validateStmt(s Stmt) error {
 	if s.Op != SEARCH && s.Op != PAGINATE {
 		errs = append(errs, ErrInvalidStmtOp)
 	}
+	if s.Op != SEARCH && s.Paginate {
+		errs = append(errs, fmt.Errorf(`%w: only SEARCH statement supports the PAGINATE prefix`, ErrMalformedStmt))
+	}
 	if s.Entity == "" {
 		errs = append(errs, ErrMissingEntity)
 	}
@@ -146,9 +149,21 @@ func (e *Encoder) stmt(s Stmt) error {
 			return err
 		}
 	}
+	if s.Paginate {
+		err := e.emit(` PAGINATE`);
+		if err != nil {
+			return err
+		}
+	}
 	if s.Context != nil && !e.onlyShape {
-		e.emit(` CONTEXT `)
-		e.expr(*s.Context, false)
+		err := e.emit(` CONTEXT `)
+		if err != nil {
+			return err
+		}
+		err = e.expr(*s.Context, false)
+		if err != nil {
+			return err
+		}
 	}
 	return e.emit(";")
 }

--- a/dql/encoder_test.go
+++ b/dql/encoder_test.go
@@ -277,10 +277,10 @@ func TestEncoder(t *testing.T) {
 			in: dql.Program{
 				Stmts: dql.Stmts{
 					{
-						Name:   "some_data",
-						Op:     dql.SEARCH,
-						Entity: "test",
-						Fields: []dql.Expr{dql.NewVarExpr("id")},
+						Name:     "some_data",
+						Op:       dql.SEARCH,
+						Entity:   "test",
+						Fields:   []dql.Expr{dql.NewVarExpr("id")},
 						Paginate: true,
 					},
 				},

--- a/dql/encoder_test.go
+++ b/dql/encoder_test.go
@@ -30,6 +30,7 @@ func TestEncoder(t *testing.T) {
 			in: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "test",
 					},
 				},
@@ -38,10 +39,25 @@ func TestEncoder(t *testing.T) {
 			shape: `SEARCH test;`,
 		},
 		{
+			name: "named stmt",
+			in: dql.Program{
+				Stmts: dql.Stmts{
+					{
+						Name:   "something",
+						Op:     dql.SEARCH,
+						Entity: "test",
+					},
+				},
+			},
+			out:   `AS something SEARCH test;`,
+			shape: `SEARCH test;`,
+		},
+		{
 			name: "stmt with only columns",
 			in: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "test",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -61,6 +77,7 @@ func TestEncoder(t *testing.T) {
 			in: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "test",
 						Where: &dql.QueryExpr{
 							LHS: dql.Path("text"),
@@ -81,6 +98,7 @@ func TestEncoder(t *testing.T) {
 			in: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "operating_systems",
 						Where: &dql.QueryExpr{
 							Type: dql.AND,
@@ -182,6 +200,7 @@ func TestEncoder(t *testing.T) {
 			in: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "test",
 						Where: &dql.QueryExpr{
 							LHS: dql.Path("text"),
@@ -203,6 +222,7 @@ func TestEncoder(t *testing.T) {
 			in: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "test",
 						Where: &dql.QueryExpr{
 							LHS: dql.Path("labels"),
@@ -223,6 +243,7 @@ func TestEncoder(t *testing.T) {
 			in: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "test",
 						Where: &dql.QueryExpr{
 							LHS: dql.Path("some", "field"),
@@ -239,6 +260,7 @@ func TestEncoder(t *testing.T) {
 			in: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "test",
 						Where: &dql.QueryExpr{
 							LHS: dql.Path("some", "field"),
@@ -249,6 +271,111 @@ func TestEncoder(t *testing.T) {
 			},
 			out:   `SEARCH test WHERE {"$missing":"some.field"};`,
 			shape: `SEARCH test WHERE {"$missing":"some.field"};`,
+		},
+		{
+			name: "PAGINATE statement",
+			in: dql.Program{
+				Stmts: dql.Stmts{
+					{
+						Name:   "some_data",
+						Op:     dql.PAGINATE,
+						Entity: "test",
+						Fields: []dql.Expr{dql.NewVarExpr("id")},
+						Context: ptr(dql.NewObjectExpr(map[string]dql.Expr{
+							"something": dql.NewNumberExpr(1),
+						})),
+					},
+				},
+			},
+			out:   `AS some_data PAGINATE test id CONTEXT {"something":1};`,
+			shape: `PAGINATE test id;`,
+		},
+		{
+			name: "PAGINATE statement with WHERE",
+			in: dql.Program{
+				Stmts: dql.Stmts{
+					{
+						Name:   "some_data",
+						Op:     dql.PAGINATE,
+						Entity: "test",
+						Fields: []dql.Expr{dql.NewVarExpr("id")},
+						Where: &dql.QueryExpr{
+							LHS: dql.Path("some", "field"),
+							OP:  dql.Missing,
+						},
+						Context: ptr(dql.NewObjectExpr(map[string]dql.Expr{
+							"something": dql.NewNumberExpr(1),
+						})),
+					},
+				},
+			},
+			out:   `AS some_data PAGINATE test id WHERE {"$missing":"some.field"} CONTEXT {"something":1};`,
+			shape: `PAGINATE test id WHERE {"$missing":"some.field"};`,
+		},
+		{
+			name: "PAGINATE statement with ORDER BY",
+			in: dql.Program{
+				Stmts: dql.Stmts{
+					{
+						Name:   "some_data",
+						Op:     dql.PAGINATE,
+						Entity: "test",
+						Fields: []dql.Expr{dql.NewVarExpr("id")},
+						Where: &dql.QueryExpr{
+							LHS: dql.Path("some", "field"),
+							OP:  dql.Missing,
+						},
+						OrderBy: []dql.OrderBy{
+							{
+								Field: dql.Path("created_at"),
+								Sort:  dql.DESC,
+							},
+							{
+								Field: dql.Path("id"),
+								Sort:  dql.DESC,
+							},
+						},
+						Context: ptr(dql.NewObjectExpr(map[string]dql.Expr{
+							"something": dql.NewNumberExpr(1),
+						})),
+					},
+				},
+			},
+			out:   `AS some_data PAGINATE test id WHERE {"$missing":"some.field"} ORDER BY created_at DESC,id DESC CONTEXT {"something":1};`,
+			shape: `PAGINATE test id WHERE {"$missing":"some.field"} ORDER BY created_at DESC,id DESC;`,
+		},
+		{
+			name: "PAGINATE statement with ORDER BY AND LIMIT",
+			in: dql.Program{
+				Stmts: dql.Stmts{
+					{
+						Name:   "some_data",
+						Op:     dql.PAGINATE,
+						Entity: "test",
+						Fields: []dql.Expr{dql.NewVarExpr("id")},
+						Where: &dql.QueryExpr{
+							LHS: dql.Path("some", "field"),
+							OP:  dql.Missing,
+						},
+						Limit: ptr(10000),
+						OrderBy: []dql.OrderBy{
+							{
+								Field: dql.Path("created_at"),
+								Sort:  dql.DESC,
+							},
+							{
+								Field: dql.Path("id"),
+								Sort:  dql.DESC,
+							},
+						},
+						Context: ptr(dql.NewObjectExpr(map[string]dql.Expr{
+							"something": dql.NewNumberExpr(1),
+						})),
+					},
+				},
+			},
+			out:   `AS some_data PAGINATE test id WHERE {"$missing":"some.field"} LIMIT 10000 ORDER BY created_at DESC,id DESC CONTEXT {"something":1};`,
+			shape: `PAGINATE test id WHERE {"$missing":"some.field"} LIMIT 10000 ORDER BY created_at DESC,id DESC;`,
 		},
 	} {
 		// normal encoding

--- a/dql/encoder_test.go
+++ b/dql/encoder_test.go
@@ -273,6 +273,22 @@ func TestEncoder(t *testing.T) {
 			shape: `SEARCH test WHERE {"$missing":"some.field"};`,
 		},
 		{
+			name: "SEARCH request PAGINATE statement",
+			in: dql.Program{
+				Stmts: dql.Stmts{
+					{
+						Name:   "some_data",
+						Op:     dql.SEARCH,
+						Entity: "test",
+						Fields: []dql.Expr{dql.NewVarExpr("id")},
+						Paginate: true,
+					},
+				},
+			},
+			out:   `AS some_data SEARCH test id PAGINATE;`,
+			shape: `SEARCH test id PAGINATE;`,
+		},
+		{
 			name: "PAGINATE statement",
 			in: dql.Program{
 				Stmts: dql.Stmts{

--- a/dql/lexer_test.go
+++ b/dql/lexer_test.go
@@ -56,7 +56,7 @@ func TestLexer(t *testing.T) {
 							value: count(labels)
 						}
 					}
-					WITH CURSOR;
+					PAGINATE;
 			`,
 			out: tokvals{
 				token(keywordToken, "AS", 5, 1, 4),
@@ -133,10 +133,9 @@ func TestLexer(t *testing.T) {
 				token(rparenToken, ")", 372, 14, 26),
 				token(rbraceToken, "}", 380, 15, 6),
 				token(rbraceToken, "}", 387, 16, 5),
-				token(keywordToken, "WITH", 394, 17, 5),
-				token(keywordToken, "CURSOR", 399, 17, 10),
-				token(semicolonToken, ";", 405, 17, 16),
-				token(eofToken, "", 410, 18, 3),
+				token(keywordToken, "PAGINATE", 394, 17, 5),
+				token(semicolonToken, ";", 402, 17, 13),
+				token(eofToken, "", 407, 18, 3),
 			},
 		},
 	} {

--- a/dql/parser.go
+++ b/dql/parser.go
@@ -2,7 +2,6 @@ package dql
 
 import (
 	"errors"
-	"fmt"
 	"slices"
 	"strconv"
 )
@@ -31,7 +30,7 @@ func Parse(in string) (Program, error) {
 			return prog, nil
 		case keywordToken:
 			switch tok.Value {
-			case "AS", "SEARCH":
+			case "AS", "SEARCH", "PAGINATE":
 				stmt, err := parseStmt(l)
 				if err != nil {
 					return Program{}, err
@@ -70,10 +69,17 @@ func parseStmt(l *lexer) (Stmt, error) {
 		if err != nil {
 			return Stmt{}, err
 		}
-		if tok.Type != keywordToken || tok.Value != "SEARCH" {
-			return Stmt{}, errUnexpectedToken(tok, "IDENT(SEARCH)")
+		if tok.Type != keywordToken {
+			return Stmt{}, errUnexpectedToken(tok, `SEARCH | PAGINATE`)
 		}
-		// fall below
+	}
+	switch tok.Value {
+	default:
+		return Stmt{}, errUnexpectedToken(tok, "SEARCH | PAGINATE")
+	case "SEARCH":
+		stmt.Op = SEARCH
+	case "PAGINATE":
+		stmt.Op = PAGINATE
 	}
 	tok, err = l.Next()
 	if err != nil {
@@ -113,8 +119,8 @@ func parseStmt(l *lexer) (Stmt, error) {
 	if tok.Type == keywordToken {
 		switch tok.Value {
 		default:
-			return Stmt{}, errUnexpectedToken(tok, "WHERE | ORDER BY | LIMIT | AGGS | WITH CURSOR | AFTER | ;")
-		case "WHERE", "AGGS", "LIMIT", "ORDER", "WITH":
+			return Stmt{}, errUnexpectedToken(tok, "WHERE | ORDER BY | LIMIT | AGGS | PAGINATE | CONTEXT;")
+		case "WHERE", "AGGS", "LIMIT", "ORDER", "PAGINATE", "CONTEXT":
 		}
 
 		if tok.Value == "WHERE" {
@@ -187,40 +193,28 @@ func parseStmt(l *lexer) (Stmt, error) {
 			}
 			stmt.OrderBy = vals
 		}
-		if tok.Value == "WITH" {
+		if tok.Value == "PAGINATE" {
 			l.Eat(1)
-			tok, err := l.Next()
-			if err != nil {
-				return Stmt{}, err
-			}
-			if tok.Type != keywordToken || tok.Value != `CURSOR` {
-				return Stmt{}, errUnexpectedToken(tok, `CURSOR`)
-			}
-			if stmt.Limit == nil || *stmt.Limit == 0 {
-				// NOTE(i4k): not sure if this should be here or in a final validation step.
-				return Stmt{}, fmt.Errorf(`%w: "WITH CURSOR" requires a "LIMIT" clause`, ErrSyntax)
-			}
-			stmt.WithCursor = true
+			stmt.Paginate = true
 			tok, err = l.Peek()
 			if err != nil {
 				return Stmt{}, err
 			}
 		}
-		if tok.Value == "AFTER" {
+		if tok.Value == "CONTEXT" {
 			l.Eat(1)
-			if stmt.Limit == nil || *stmt.Limit == 0 {
-				// NOTE(i4k): not sure if this should be here or in a final validation step.
-				return Stmt{}, fmt.Errorf(`%w: "WITH CURSOR" requires a "LIMIT" clause`, ErrSyntax)
-			}
-			expr, err := parseExpr(l)
+			tok, err := l.Peek()
 			if err != nil {
 				return Stmt{}, err
 			}
-			stmt.After = expr
-			tok, err = l.Peek()
+			if tok.Type != lbraceToken {
+				return Stmt{}, errUnexpectedToken(tok, `{`)
+			}
+			obj, err := parseObjectExpr(l)
 			if err != nil {
 				return Stmt{}, err
 			}
+			stmt.Context = &obj
 		}
 		if tok.Value == "AGGS" {
 			l.Eat(1)
@@ -233,8 +227,6 @@ func parseStmt(l *lexer) (Stmt, error) {
 				return Stmt{}, err
 			}
 		}
-
-		// TODO(i4k): ORDER BY, WITH CURSOR, etc
 	}
 
 	// TODO(i4k): rest

--- a/dql/parser_aggs_test.go
+++ b/dql/parser_aggs_test.go
@@ -23,6 +23,7 @@ func TestParserAggs(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Aggs:   dql.Aggs{},
 					},
@@ -35,6 +36,7 @@ func TestParserAggs(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Limit:  ptr(0),
 						Aggs:   dql.Aggs{},
@@ -50,6 +52,7 @@ func TestParserAggs(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Aggs: dql.Aggs{
 							"by_labels": dql.Agg{
@@ -75,6 +78,7 @@ func TestParserAggs(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Aggs: dql.Aggs{
 							"labels": {

--- a/dql/parser_test.go
+++ b/dql/parser_test.go
@@ -702,7 +702,7 @@ func TestParser(t *testing.T) {
 		},
 		{
 			name: "advanced PAGINATE stmt",
-			in: `PAGINATE feedbacks
+			in: `AS something PAGINATE feedbacks
 					id, text
 				WHERE {
 					"$and":[{"text": "test"}]
@@ -716,6 +716,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Name:   "something",
 						Op:     dql.PAGINATE,
 						Entity: "feedbacks",
 						Fields: []dql.Expr{

--- a/dql/parser_test.go
+++ b/dql/parser_test.go
@@ -23,6 +23,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 					},
 				},
@@ -34,6 +35,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Limit:  ptr(10),
 					},
@@ -46,9 +48,11 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 					},
 					{
+						Op:     dql.SEARCH,
 						Entity: "orders",
 					},
 				},
@@ -60,6 +64,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -76,6 +81,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -106,6 +112,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -139,6 +146,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -159,6 +167,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "orders",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -185,6 +194,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "orders",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -225,6 +235,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "orders",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -279,6 +290,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "orders",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -329,6 +341,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "orders",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -373,6 +386,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "orders",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -412,6 +426,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "orders",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -444,6 +459,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "orders",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -496,6 +512,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -542,6 +559,7 @@ func TestParser(t *testing.T) {
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.SEARCH,
 						Entity: "feedbacks",
 						Fields: []dql.Expr{
 							dql.NewVarExpr("id"),
@@ -570,27 +588,28 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
-			name: "WITH CURSOR",
-			in:   `SEARCH feedbacks LIMIT 10 WITH CURSOR;`,
+			name: "PAGINATE",
+			in:   `SEARCH feedbacks PAGINATE;`,
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
-						Entity:     "feedbacks",
-						Limit:      ptr(10),
-						WithCursor: true,
+						Op:       dql.SEARCH,
+						Entity:   "feedbacks",
+						Paginate: true,
 					},
 				},
 			},
 		},
 		{
 			name: "ORDER BY field",
-			in:   `SEARCH feedbacks LIMIT 10 ORDER BY posted_at WITH CURSOR;`,
+			in:   `SEARCH feedbacks LIMIT 10 ORDER BY posted_at PAGINATE;`,
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
-						Entity:     "feedbacks",
-						Limit:      ptr(10),
-						WithCursor: true,
+						Op:       dql.SEARCH,
+						Entity:   "feedbacks",
+						Limit:    ptr(10),
+						Paginate: true,
 						OrderBy: []dql.OrderBy{
 							{Field: dql.Path("posted_at")},
 						},
@@ -600,13 +619,14 @@ func TestParser(t *testing.T) {
 		},
 		{
 			name: "ORDER BY field DESC",
-			in:   `SEARCH feedbacks LIMIT 10 ORDER BY posted_at DESC WITH CURSOR;`,
+			in:   `SEARCH feedbacks LIMIT 10 ORDER BY posted_at DESC PAGINATE;`,
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
-						Entity:     "feedbacks",
-						Limit:      ptr(10),
-						WithCursor: true,
+						Op:       dql.SEARCH,
+						Entity:   "feedbacks",
+						Limit:    ptr(10),
+						Paginate: true,
 						OrderBy: []dql.OrderBy{
 							{Field: dql.Path("posted_at"), Sort: dql.DESC},
 						},
@@ -616,13 +636,14 @@ func TestParser(t *testing.T) {
 		},
 		{
 			name: "ORDER BY field with path",
-			in:   `SEARCH orders LIMIT 10 ORDER BY feedbacks.posted_at DESC WITH CURSOR;`,
+			in:   `SEARCH orders LIMIT 10 ORDER BY feedbacks.posted_at DESC PAGINATE;`,
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
-						Entity:     "orders",
-						Limit:      ptr(10),
-						WithCursor: true,
+						Op:       dql.SEARCH,
+						Entity:   "orders",
+						Limit:    ptr(10),
+						Paginate: true,
 						OrderBy: []dql.OrderBy{
 							{Field: dql.Path("feedbacks", "posted_at"), Sort: dql.DESC},
 						},
@@ -632,13 +653,14 @@ func TestParser(t *testing.T) {
 		},
 		{
 			name: "multiple ORDER BY clauses",
-			in:   `SEARCH orders LIMIT 10 ORDER BY feedbacks.posted_at DESC, id WITH CURSOR;`,
+			in:   `SEARCH orders LIMIT 10 ORDER BY feedbacks.posted_at DESC, id PAGINATE;`,
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
-						Entity:     "orders",
-						Limit:      ptr(10),
-						WithCursor: true,
+						Op:       dql.SEARCH,
+						Entity:   "orders",
+						Limit:    ptr(10),
+						Paginate: true,
 						OrderBy: []dql.OrderBy{
 							{Field: dql.Path("feedbacks", "posted_at"), Sort: dql.DESC},
 							{Field: dql.Path("id")},
@@ -649,13 +671,14 @@ func TestParser(t *testing.T) {
 		},
 		{
 			name: "multiple ORDER BY clauses with direction",
-			in:   `SEARCH orders LIMIT 10 ORDER BY feedbacks.posted_at DESC, id DESC WITH CURSOR;`,
+			in:   `SEARCH orders LIMIT 10 ORDER BY feedbacks.posted_at DESC, id DESC PAGINATE;`,
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
-						Entity:     "orders",
-						Limit:      ptr(10),
-						WithCursor: true,
+						Op:       dql.SEARCH,
+						Entity:   "orders",
+						Limit:    ptr(10),
+						Paginate: true,
 						OrderBy: []dql.OrderBy{
 							{Field: dql.Path("feedbacks", "posted_at"), Sort: dql.DESC},
 							{Field: dql.Path("id"), Sort: dql.DESC},
@@ -665,40 +688,61 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
-			name: "WITH CURSOR WITHOUT LIMIT is an error",
-			in:   `SEARCH feedbacks WITH CURSOR;`,
-			err:  dql.ErrSyntax,
-		},
-		{
-			name: "AFTER stringExpr",
-			in:   `SEARCH feedbacks LIMIT 10 AFTER "test";`,
+			name: "simplest PAGINATE stmt",
+			in:   `PAGINATE feedbacks CONTEXT {};`,
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
-						Entity: "feedbacks",
-						Limit:  ptr(10),
-						After:  dql.NewStringExpr("test"),
+						Op:      dql.PAGINATE,
+						Entity:  "feedbacks",
+						Context: ptr(dql.NewObjectExpr(map[string]dql.Expr{})),
 					},
 				},
 			},
 		},
 		{
-			name: "AFTER variable",
-			in:   `SEARCH feedbacks LIMIT 10 AFTER first_page.next_cursor;`,
+			name: "advanced PAGINATE stmt",
+			in: `PAGINATE feedbacks
+					id, text
+				WHERE {
+					"$and":[{"text": "test"}]
+				}
+				LIMIT 1000
+				ORDER BY created_at ASC, id ASC
+				CONTEXT {
+					"a": 1,
+					"b": 2
+				};`,
 			out: dql.Program{
 				Stmts: dql.Stmts{
 					{
+						Op:     dql.PAGINATE,
 						Entity: "feedbacks",
-						Limit:  ptr(10),
-						After:  dql.NewPathExpr(dql.NewVarExpr("first_page"), dql.NewFieldStep("next_cursor")),
+						Fields: []dql.Expr{
+							dql.NewVarExpr("id"), dql.NewVarExpr("text"),
+						},
+						Where: &dql.QueryExpr{
+							Type: dql.AND,
+							Children: []*dql.QueryExpr{
+								{
+									OP:  dql.Eq,
+									LHS: dql.Path("text"),
+									RHS: dql.NewStringExpr("test"),
+								},
+							},
+						},
+						Limit: ptr(1000),
+						OrderBy: []dql.OrderBy{
+							{Field: dql.Path("created_at")},
+							{Field: dql.Path("id")},
+						},
+						Context: ptr(dql.NewObjectExpr(map[string]dql.Expr{
+							"a": dql.NewNumberExpr(1),
+							"b": dql.NewNumberExpr(2),
+						})),
 					},
 				},
 			},
-		},
-		{
-			name: "AFTER WITHOUT LIMIT is an error",
-			in:   `SEARCH feedbacks AFTER "test";`,
-			err:  dql.ErrSyntax,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/dql/token.go
+++ b/dql/token.go
@@ -42,21 +42,20 @@ const (
 )
 
 var keywords = map[string]struct{}{
-	"AS":     {},
-	"SEARCH": {},
-	"RETURN": {},
-	"WHERE":  {},
-	"ORDER":  {},
-	"BY":     {},
-	"LIMIT":  {},
-	"ASC":    {},
-	"DESC":   {},
-	"AGGS":   {},
-	"WITH":   {},
-	"CURSOR": {},
-	"AFTER":  {},
-	"AND":    {},
-	"OR":     {},
+	"AS":       {},
+	"SEARCH":   {},
+	"PAGINATE": {},
+	"RETURN":   {},
+	"WHERE":    {},
+	"ORDER":    {},
+	"BY":       {},
+	"LIMIT":    {},
+	"ASC":      {},
+	"DESC":     {},
+	"AGGS":     {},
+	"CONTEXT":  {},
+	"AND":      {},
+	"OR":       {},
 }
 
 func (t tokval) String() string {


### PR DESCRIPTION
Add parsing support for `SEARCH ... PAGINATE` and `PAGINATE ...` statements.

```
SEARCH feedbacks
  id, text
WHERE text ~= "fraud"
LIMIT 1000
PAGINATE;
```
The statement above ask for first page and request a pagination.
If more than 1 page exists, then a `next` field comes back with the next statement that should be sent. It has the syntax below:
```
PAGINATE <entity> ... CONTEXT { ... };
```