### PR TITLE
feat: DML pruning by stmt

### DIFF
--- a/dml/ast.go
+++ b/dml/ast.go
@@ -12,11 +12,12 @@ type (
 	// The [Stmt.Inner] are data manipulations in the inner relationships of the outer entity.
 	// All stmts in the [Stmt.Inner] are restricted by the `WHERE` clause in the outer stmt.
 	Stmt struct {
-		Entity unique.Handle[string]
-		Op     OpKind
-		Assign Assign
-		Inner  Stmts
-		Where  Where
+		Entity  unique.Handle[string]
+		Op      OpKind
+		Assign  Assign
+		Inner   Stmts
+		Where   Where
+		Pruning Pruning
 	}
 
 	// Stmts is a list of statements.
@@ -50,6 +51,9 @@ type (
 
 	// Where clause of the update.
 	Where map[string]any
+
+	// Pruning by fields.
+	Pruning map[string]any
 
 	// Primtype is a constraint for the primitive types supported in dml.
 	Primtype interface {

--- a/dml/encoder.go
+++ b/dml/encoder.go
@@ -92,6 +92,11 @@ func validate(stmt Stmt) error {
 			errs = append(errs, fmt.Errorf("clause with invalid field %s: %w", k, ErrNotIdent))
 		}
 	}
+	for k := range stmt.Pruning {
+		if !isIdent(k) {
+			errs = append(errs, fmt.Errorf("clause with invalid field %s: %w", k, ErrNotIdent))
+		}
+	}
 	for _, innerStmt := range stmt.Inner {
 		errs = append(errs, validate(innerStmt))
 	}
@@ -143,6 +148,37 @@ func encodeStmtExpr(w io.Writer, stmt Stmt) error {
 	err = encodeClauses(w, stmt.Where)
 	if err != nil {
 		return err
+	}
+	if len(stmt.Pruning) > 0 {
+		err = write(w, " PRUNING BY ")
+		if err != nil {
+			return err
+		}
+		err = encodePruning(w, stmt.Pruning)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func encodePruning(w io.Writer, pruning Pruning) error {
+	keys := slices.Sorted(maps.Keys(pruning))
+	for i, k := range keys {
+		d, err := json.Marshal(pruning[k])
+		if err != nil {
+			return err
+		}
+		err = write(w, k+"="+string(d))
+		if err != nil {
+			return err
+		}
+		if i+1 < len(keys) {
+			err = write(w, ",")
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }

--- a/dml/encoder_test.go
+++ b/dml/encoder_test.go
@@ -788,6 +788,58 @@ func TestEncode(t *testing.T) {
 			},
 			want: `DELETE feedbacks a.b[k] : k="test",a.b.c[k] => v : k="country" AND v="us" WHERE {"id":"abc","org_id":"xyz"};`,
 		},
+		{
+			name: "stmt with pruning by single field",
+			ast: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("feedbacks"),
+					Assign: dml.Assign{"a": 1.0},
+					Where: dml.Where{
+						"id": "abc",
+					},
+					Pruning: dml.Pruning{
+						"organization_id": "org-1",
+					},
+				},
+			},
+			want: `SET feedbacks a=1 WHERE id="abc" PRUNING BY organization_id="org-1";`,
+		},
+		{
+			name: "stmt with pruning by multiple fields",
+			ast: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("feedbacks"),
+					Assign: dml.Assign{"a": 1.0},
+					Where: dml.Where{
+						"id": "abc",
+					},
+					Pruning: dml.Pruning{
+						"organization_id": "org-1",
+						"posted_at":       "2026-05-27 15:04:28+00:00",
+					},
+				},
+			},
+			want: `SET feedbacks a=1 WHERE id="abc" PRUNING BY organization_id="org-1",posted_at="2026-05-27 15:04:28+00:00";`,
+		},
+		{
+			name: "invalid ident in pruning",
+			ast: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("feedbacks"),
+					Assign: dml.Assign{"a": 1.0},
+					Where: dml.Where{
+						"id": "abc",
+					},
+					Pruning: dml.Pruning{
+						"$bad": "x",
+					},
+				},
+			},
+			err: dml.ErrNotIdent,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf bytes.Buffer

--- a/dml/parser.go
+++ b/dml/parser.go
@@ -122,6 +122,11 @@ func parseStmtExpr(in []byte) (Stmt, []byte, error) {
 	if err != nil {
 		return Stmt{}, nil, err
 	}
+	in = skipblank(in)
+	stmt.Pruning, in, err = parsePruning(in)
+	if err != nil {
+		return Stmt{}, nil, err
+	}
 	return stmt, in, nil
 }
 
@@ -698,6 +703,64 @@ func parseWhereObject(in []byte) (Where, []byte, error) {
 		}
 	}
 	return where, in, nil
+}
+
+func parsePruning(in []byte) (Pruning, []byte, error) {
+	// PRUNING BY is optional
+	if len(in) < 7 || !bytes.EqualFold(in[:7], []byte("PRUNING")) {
+		return nil, in, nil
+	}
+	in = skipblank(in[7:])
+	if len(in) == 0 {
+		return nil, nil, errUnexpectedEOF()
+	}
+	ident, in, err := lexIdent(in)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", ErrSyntax, err)
+	}
+	if !strings.EqualFold(ident, "BY") {
+		return nil, nil, fmt.Errorf("%w: expected BY token after PRUNING", ErrSyntax)
+	}
+	pruning := Pruning{}
+	for {
+		in = skipblank(in)
+		if len(in) == 0 {
+			return nil, nil, errUnexpectedEOF()
+		}
+		var key string
+		key, in, err = lexIdent(in)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%w: %v", ErrSyntax, err)
+		}
+		in = skipblank(in)
+		if len(in) == 0 {
+			return nil, nil, errUnexpectedEOF()
+		}
+		if in[0] != '=' {
+			return nil, nil, fmt.Errorf("%w: expected '=' in PRUNING BY clause", ErrSyntax)
+		}
+		in = skipblank(in[1:])
+		if len(in) == 0 {
+			return nil, nil, errUnexpectedEOF()
+		}
+		var val any
+		in, err = parseJSON(in, &val)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%w: parsing PRUNING value as JSON: %v", ErrSyntax, err)
+		}
+		if _, ok := pruning[key]; ok {
+			return nil, nil, fmt.Errorf("%w: duplicate PRUNING field %q", ErrClauseDuplicated, key)
+		}
+		pruning[key] = val
+		in = skipblank(in)
+		if len(in) == 0 {
+			return nil, nil, errUnexpectedEOF()
+		}
+		if in[0] != ',' {
+			return pruning, in, nil
+		}
+		in = in[1:]
+	}
 }
 
 func mergeclauses(dst, src Where) error {

--- a/dml/parser.go
+++ b/dml/parser.go
@@ -123,26 +123,30 @@ func parseStmtExpr(in []byte) (Stmt, []byte, error) {
 		return Stmt{}, nil, err
 	}
 	in = skipblank(in)
-	if len(in) >= 7 && bytes.EqualFold(in[:7], []byte("PRUNING")) {
-		in = skipblank(in[7:])
-		if len(in) == 0 {
-			return Stmt{}, nil, errUnexpectedEOF()
-		}
-		ident, in, err = lexIdent(in)
-		if err != nil {
-			return Stmt{}, nil, fmt.Errorf("%w: expected BY keyword: %w", ErrSyntax, err)
-		}
-		if !strings.EqualFold(ident, "BY") {
-			return Stmt{}, nil, fmt.Errorf("%w: expected BY keyword, got %q", ErrSyntax, ident)
-		}
-		in = skipblank(in)
-		if len(in) == 0 {
-			return Stmt{}, nil, errUnexpectedEOF()
-		}
-		stmt.Pruning, in, err = parsePruning(in)
-		if err != nil {
-			return Stmt{}, nil, err
-		}
+	saved := in
+	ident, in, err = lexIdent(in)
+	isNotIdent := errors.Is(err, ErrNotIdent)
+	if err != nil && !isNotIdent {
+		return Stmt{}, nil, fmt.Errorf("%w: %w", ErrSyntax, err)
+	}
+	if isNotIdent {
+		return stmt, saved, nil
+	}
+	if !strings.EqualFold(ident, "PRUNING") {
+		return Stmt{}, nil, fmt.Errorf("%w: unexpected token %q", ErrSyntax, ident)
+	}
+	in = skipblank(in)
+	ident, in, err = lexIdent(in)
+	if err != nil {
+		return Stmt{}, nil, fmt.Errorf("%w: expected BY keyword: %w", ErrSyntax, err)
+	}
+	if !strings.EqualFold(ident, "BY") {
+		return Stmt{}, nil, fmt.Errorf("%w: unexpected token %q", ErrSyntax, ident)
+	}
+	in = skipblank(in)
+	stmt.Pruning, in, err = parsePruning(in)
+	if err != nil {
+		return Stmt{}, nil, err
 	}
 	return stmt, in, nil
 }

--- a/dml/parser.go
+++ b/dml/parser.go
@@ -123,27 +123,26 @@ func parseStmtExpr(in []byte) (Stmt, []byte, error) {
 		return Stmt{}, nil, err
 	}
 	in = skipblank(in)
-	ident, in, err = lexIdent(in)
-	isNotIdent := errors.Is(err, ErrNotIdent)
-	if err != nil && !isNotIdent {
-		return Stmt{}, nil, err
-	}
-	if isNotIdent {
-	    return stmt, in, nil
-	}
-	if !strings.EqualFold(ident, "PRUNING") {
-		return Stmt{}, nil, fmt.Errorf("%w: unexpected token %q", ErrSyntax, ident)
-	}
-	ident, in, err = lexIdent(in)
-	if err != nil {
-		return Stmt{}, nil, fmt.Errorf(`%w: expected BY keyword`, ErrSyntax, err)
-	}
-	if !strings.EqualFold(ident, "BY") {
-		return Stmt{}, nil, fmt.Errorf("%w: unexpected token %q", ErrSyntax, ident)
-	}
-	stmt.Pruning, in, err = parsePruning(in)
-	if err != nil {
-		return Stmt{}, nil, err
+	if len(in) >= 7 && bytes.EqualFold(in[:7], []byte("PRUNING")) {
+		in = skipblank(in[7:])
+		if len(in) == 0 {
+			return Stmt{}, nil, errUnexpectedEOF()
+		}
+		ident, in, err = lexIdent(in)
+		if err != nil {
+			return Stmt{}, nil, fmt.Errorf("%w: expected BY keyword: %w", ErrSyntax, err)
+		}
+		if !strings.EqualFold(ident, "BY") {
+			return Stmt{}, nil, fmt.Errorf("%w: expected BY keyword, got %q", ErrSyntax, ident)
+		}
+		in = skipblank(in)
+		if len(in) == 0 {
+			return Stmt{}, nil, errUnexpectedEOF()
+		}
+		stmt.Pruning, in, err = parsePruning(in)
+		if err != nil {
+			return Stmt{}, nil, err
+		}
 	}
 	return stmt, in, nil
 }
@@ -724,22 +723,8 @@ func parseWhereObject(in []byte) (Where, []byte, error) {
 }
 
 func parsePruning(in []byte) (Pruning, []byte, error) {
-	// PRUNING BY is optional
-	if len(in) < 7 || !bytes.EqualFold(in[:7], []byte("PRUNING")) {
-		return nil, in, nil
-	}
-	in = skipblank(in[7:])
-	if len(in) == 0 {
-		return nil, nil, errUnexpectedEOF()
-	}
-	ident, in, err := lexIdent(in)
-	if err != nil {
-		return nil, nil, fmt.Errorf("%w: %w", ErrSyntax, err)
-	}
-	if !strings.EqualFold(ident, "BY") {
-		return nil, nil, fmt.Errorf("%w: expected BY token after PRUNING", ErrSyntax)
-	}
 	pruning := Pruning{}
+	var err error
 	for {
 		in = skipblank(in)
 		if len(in) == 0 {

--- a/dml/parser.go
+++ b/dml/parser.go
@@ -123,6 +123,24 @@ func parseStmtExpr(in []byte) (Stmt, []byte, error) {
 		return Stmt{}, nil, err
 	}
 	in = skipblank(in)
+	ident, in, err = lexIdent(in)
+	isNotIdent := errors.Is(err, ErrNotIdent)
+	if err != nil && !isNotIdent {
+		return Stmt{}, nil, err
+	}
+	if isNotIdent {
+	    return stmt, in, nil
+	}
+	if !strings.EqualFold(ident, "PRUNING") {
+		return Stmt{}, nil, fmt.Errorf("%w: unexpected token %q", ErrSyntax, ident)
+	}
+	ident, in, err = lexIdent(in)
+	if err != nil {
+		return Stmt{}, nil, fmt.Errorf(`%w: expected BY keyword`, ErrSyntax, err)
+	}
+	if !strings.EqualFold(ident, "BY") {
+		return Stmt{}, nil, fmt.Errorf("%w: unexpected token %q", ErrSyntax, ident)
+	}
 	stmt.Pruning, in, err = parsePruning(in)
 	if err != nil {
 		return Stmt{}, nil, err

--- a/dml/parser.go
+++ b/dml/parser.go
@@ -123,15 +123,15 @@ func parseStmtExpr(in []byte) (Stmt, []byte, error) {
 		return Stmt{}, nil, err
 	}
 	in = skipblank(in)
-	saved := in
-	ident, in, err = lexIdent(in)
+	ident, newInput, err := lexIdent(in)
 	isNotIdent := errors.Is(err, ErrNotIdent)
 	if err != nil && !isNotIdent {
 		return Stmt{}, nil, fmt.Errorf("%w: %w", ErrSyntax, err)
 	}
 	if isNotIdent {
-		return stmt, saved, nil
+		return stmt, in, nil
 	}
+	in = newInput
 	if !strings.EqualFold(ident, "PRUNING") {
 		return Stmt{}, nil, fmt.Errorf("%w: unexpected token %q", ErrSyntax, ident)
 	}

--- a/dml/parser_test.go
+++ b/dml/parser_test.go
@@ -822,6 +822,67 @@ func TestParser(t *testing.T) {
 				},
 			},
 		},
+		{
+			text: `SET feedbacks a=1 WHERE id="abc" PRUNING BY organization_id="org-1";`,
+			want: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("feedbacks"),
+					Assign: dml.Assign{"a": 1.0},
+					Where:  dml.Where{"id": "abc"},
+					Pruning: dml.Pruning{
+						"organization_id": "org-1",
+					},
+				},
+			},
+		},
+		{
+			text: `SET feedbacks a=1 WHERE id="abc" PRUNING BY organization_id="org-1",posted_at="ts";`,
+			want: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("feedbacks"),
+					Assign: dml.Assign{"a": 1.0},
+					Where:  dml.Where{"id": "abc"},
+					Pruning: dml.Pruning{
+						"organization_id": "org-1",
+						"posted_at":       "ts",
+					},
+				},
+			},
+		},
+		{
+			noEncoderTest: true,
+			text:          `SET feedbacks a=1 WHERE id="abc" PRUNING BY organization_id = "org-1" , posted_at = "ts";`,
+			want: dml.Stmts{
+				{
+					Op:     dml.SET,
+					Entity: u("feedbacks"),
+					Assign: dml.Assign{"a": 1.0},
+					Where:  dml.Where{"id": "abc"},
+					Pruning: dml.Pruning{
+						"organization_id": "org-1",
+						"posted_at":       "ts",
+					},
+				},
+			},
+		},
+		{
+			text: `SET feedbacks a=1 WHERE id="abc" PRUNING;`,
+			err:  dml.ErrSyntax,
+		},
+		{
+			text: `SET feedbacks a=1 WHERE id="abc" PRUNING BY;`,
+			err:  dml.ErrSyntax,
+		},
+		{
+			text: `SET feedbacks a=1 WHERE id="abc" PRUNING WRONG organization_id="org-1";`,
+			err:  dml.ErrSyntax,
+		},
+		{
+			text: `SET feedbacks a=1 WHERE id="abc" PRUNING BY a="x",a="y";`,
+			err:  dml.ErrClauseDuplicated,
+		},
 	} {
 		got, err := dml.Parse([]byte(tc.text))
 		if !errors.Is(err, tc.err) {


### PR DESCRIPTION
Implementing "PRUNING BY" syntax.

Example:
```
SET feedbacks
  custom_fields.abc={ ... }
WHERE id="abc"
PRUNING BY
  posted_at="2026-05-27 15:04:28+00:00",
  ingested_at="2026-05-28 15:04:28+00:00";
```

Pruning should be used as a "tip" to identify partitions and improve some SET stmts.