### PR TITLE
fix(xhttp): set Content-Type application/json on NewJSONRequest

### DIFF
--- a/xhttp/request.go
+++ b/xhttp/request.go
@@ -70,5 +70,10 @@ func NewJSONRequest(ctx context.Context, method, url string, data any) (*http.Re
 	if err != nil {
 		return nil, err
 	}
-	return NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
+	req, err := NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
 }

--- a/xhttp/request_test.go
+++ b/xhttp/request_test.go
@@ -25,3 +25,15 @@ func TestRequestUserAgent(t *testing.T) {
 		t.Fatalf("got user agent %q; want %q", v.UserAgent(), want)
 	}
 }
+
+func TestJSONRequestContentType(t *testing.T) {
+	v, err := xhttp.NewJSONRequest(context.Background(), http.MethodPost, "http://test", map[string]string{"key": "value"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "application/json"
+	got := v.Header.Get("Content-Type")
+	if want != got {
+		t.Fatalf("got content type %q; want %q", got, want)
+	}
+}


### PR DESCRIPTION
- NewJSONRequest marshals the body as JSON but never set `Content-Type`; backends that started requiring the header rejected requests with 422
- set `application/json` on the request 